### PR TITLE
Web support 

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http_parser/http_parser.dart' show MediaType;
 import 'package:mime/mime.dart';
 import 'package:storage_client/src/types.dart';
+import 'package:universal_io/io.dart';
 
 Fetch fetch = Fetch();
 

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -1,5 +1,6 @@
-import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:universal_io/io.dart';
 
 import 'fetch.dart';
 import 'types.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   http: ^0.13.0
   http_parser: ^4.0.0
   mime: ^1.0.0
+  universal_io: ^2.0.4
+
 
 dev_dependencies:
   lint: ^1.5.1


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix, feature

## What is the current behavior?
storage_client does not support the web because of the `dart:io` import
#2 

## What is the new behavior?
replaced `dart:io` with [universal_io](https://pub.dev/packages/universal_io)
so it should support the web now

## Additional context
I couldn't run the `client_test.dart` because I don't have docker currently installed
but the example did work with no errors