### PR TITLE
Add public option for createBucket method, and add updateBucket

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PGRST_DB_ANON_ROLE: postgres
       PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
   storage:
-    image: supabase/storage-api:v0.2.1
+    image: supabase/storage-api:v0.3.1
     ports:
       - '5000:5000'
     depends_on:
@@ -38,10 +38,10 @@ services:
       PROJECT_REF: bjwdssmqcnupljrqypxz # can be any random string
       REGION: us-east-1 # region where your bucket is located
       POSTGREST_URL: http://rest:3000
-      GLOBAL_S3_BUCKET: supa-storage-testing  # name of s3 bucket where you want to store objects
+      GLOBAL_S3_BUCKET: supa-storage-testing # name of s3 bucket where you want to store objects
       PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
       DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
-      PGOPTIONS: "-c search_path=storage"
+      PGOPTIONS: '-c search_path=storage'
       AWS_ACCESS_KEY_ID: replace-with-your-aws-key
       AWS_SECRET_ACCESS_KEY: replace-with-your-aws-secret
       FILE_SIZE_LIMIT: 52428800

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -38,10 +38,10 @@ services:
       PROJECT_REF: bjwdssmqcnupljrqypxz # can be any random string
       REGION: us-east-1 # region where your bucket is located
       POSTGREST_URL: http://rest:3000
-      GLOBAL_S3_BUCKET: supa-storage-testing # name of s3 bucket where you want to store objects
+      GLOBAL_S3_BUCKET: supa-storage-testing  # name of s3 bucket where you want to store objects
       PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
       DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
-      PGOPTIONS: '-c search_path=storage'
+      PGOPTIONS: "-c search_path=storage"
       AWS_ACCESS_KEY_ID: replace-with-your-aws-key
       AWS_SECRET_ACCESS_KEY: replace-with-your-aws-secret
       FILE_SIZE_LIMIT: 52428800

--- a/lib/src/storage_bucket_api.dart
+++ b/lib/src/storage_bucket_api.dart
@@ -76,8 +76,8 @@ class StorageBucketApi {
     try {
       final FetchOptions options = FetchOptions(headers: headers);
       final response = await fetch.put(
-        '$url/bucket',
-        {'id': id, 'name': id, 'public': bucketOptions.public},
+        '$url/bucket/$id',
+        {'id': id, 'public': bucketOptions.public},
         options: options,
       );
       if (response.hasError) {

--- a/lib/src/storage_bucket_api.dart
+++ b/lib/src/storage_bucket_api.dart
@@ -44,13 +44,16 @@ class StorageBucketApi {
   /// Creates a new Storage bucket
   ///
   /// @param id A unique identifier for the bucket you are creating.
+  /// @param bucketOptions A parameter to optionally make the bucket public.
   /// @return created bucket id
-  Future<StorageResponse<String>> createBucket(String id) async {
+  Future<StorageResponse<String>> createBucket(String id,
+      [BucketOptions bucketOptions =
+          const BucketOptions(public: false)]) async {
     try {
       final FetchOptions options = FetchOptions(headers: headers);
       final response = await fetch.post(
         '$url/bucket',
-        {'id': id, 'name': id},
+        {'id': id, 'name': id, 'public': bucketOptions.public},
         options: options,
       );
       if (response.hasError) {

--- a/lib/src/storage_bucket_api.dart
+++ b/lib/src/storage_bucket_api.dart
@@ -67,6 +67,30 @@ class StorageBucketApi {
     }
   }
 
+  /// Updates a new Storage bucket
+  ///
+  /// @param id A unique identifier for the bucket you are creating.
+  /// @param bucketOptions A parameter to set the publicity of the bucket.
+  Future<StorageResponse<String>> updateBucket(
+      String id, BucketOptions bucketOptions) async {
+    try {
+      final FetchOptions options = FetchOptions(headers: headers);
+      final response = await fetch.put(
+        '$url/bucket',
+        {'id': id, 'name': id, 'public': bucketOptions.public},
+        options: options,
+      );
+      if (response.hasError) {
+        return StorageResponse(error: response.error);
+      } else {
+        final message = response.data['message'] as String;
+        return StorageResponse<String>(data: message);
+      }
+    } catch (e) {
+      return StorageResponse(error: StorageError(e.toString()));
+    }
+  }
+
   /// Removes all objects inside a single bucket.
   ///
   /// @param id The unique identifier of the bucket you would like to empty.

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -5,6 +5,7 @@ class Bucket {
     required this.owner,
     required this.createdAt,
     required this.updatedAt,
+    required this.public,
   });
 
   Bucket.fromJson(dynamic json)
@@ -13,13 +14,15 @@ class Bucket {
         name = json['name'] as String,
         owner = json['owner'] as String,
         createdAt = json['created_at'] as String,
-        updatedAt = json['updated_at'] as String;
+        updatedAt = json['updated_at'] as String,
+        public = json['public'] as bool;
 
   final String id;
   final String name;
   final String owner;
   final String createdAt;
   final String updatedAt;
+  final bool public;
 }
 
 class FileObject {
@@ -58,6 +61,12 @@ class FileObject {
   final String? lastAccessedAt;
   final Metadata? metadata;
   final Bucket? buckets;
+}
+
+class BucketOptions {
+  const BucketOptions({required this.public});
+
+  final bool public;
 }
 
 class FileOptions {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -21,6 +21,7 @@ Map<String, dynamic> get testBucketJson => {
       'owner': 'owner_id',
       'created_at': '',
       'updated_at': '',
+      'public': false,
     };
 
 Map<String, dynamic> get testFileObjectJson => {
@@ -71,7 +72,11 @@ void main() {
 
   test('should create bucket', () async {
     const testBucketId = 'test_bucket';
-    const requestBody = {'id': testBucketId, 'name': testBucketId};
+    const requestBody = {
+      'id': testBucketId,
+      'name': testBucketId,
+      'public': false
+    };
     when(() => fetch.post(bucketUrl, requestBody, options: mockFetchOptions))
         .thenAnswer((_) =>
             Future.value(StorageResponse(data: {'name': 'test_bucket'})));

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -44,6 +44,14 @@ void main() {
     expect(response.data, newBucketName);
   });
 
+  test('Create new public bucket', () async {
+    const newPublicBucketName = 'my-new-public-bucket';
+    await client.createBucket(
+        newPublicBucketName, const BucketOptions(public: true));
+    final response = await client.getBucket(newPublicBucketName);
+    expect(response.data!.public, true);
+  });
+
   test('Empty bucket', () async {
     final response = await client.emptyBucket(newBucketName);
     expect(response.data, 'Successfully emptied');

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -52,6 +52,15 @@ void main() {
     expect(response.data!.public, true);
   });
 
+  test('update bucket', () async {
+    final updateRes = await client.updateBucket(
+        newBucketName, const BucketOptions(public: true));
+    expect(updateRes.error, isNull);
+    expect(updateRes.data, isA<String>());
+    final getRes = await client.getBucket(newBucketName);
+    expect(getRes.data!.public, true);
+  });
+
   test('Empty bucket', () async {
     final response = await client.emptyBucket(newBucketName);
     expect(response.data, 'Successfully emptied');


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR matches [this PR](https://github.com/supabase/storage-js/pull/12) in storage-js. 

## What is the current behavior?

There are no option to create public bucket

## What is the new behavior?

Users can create public bucket, as well as update existing buckets to be public. 
