### PR TITLE
Added upsert field to FileOptions

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -123,7 +123,8 @@ class Fetch {
       final request = http.MultipartRequest(method, Uri.parse(url))
         ..headers.addAll(headers)
         ..files.add(multipartFile)
-        ..fields['cacheControl'] = fileOptions.cacheControl;
+        ..fields['cacheControl'] = fileOptions.cacheControl
+        ..headers['x-upsert'] = fileOptions.upsert.toString();
 
       final streamedResponse = await request.send();
       final response = await http.Response.fromStream(streamedResponse);

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -70,9 +70,10 @@ class BucketOptions {
 }
 
 class FileOptions {
-  const FileOptions({required this.cacheControl});
+  const FileOptions({required this.cacheControl, this.upsert = false});
 
   final String cacheControl;
+  final bool upsert;
 }
 
 class SearchOptions {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds an `upsert` option to `upload` method

Closes #7 

## What is the current behavior?

There is no upsert option

## What is the new behavior?

Users can upsert files to their Supabase storage

## Other context

Tested locally and was able to successfully perform a upsert request. 