### PR TITLE
fix: cacheControl is now sent inside the header instead of body

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -123,7 +123,7 @@ class Fetch {
       final request = http.MultipartRequest(method, Uri.parse(url))
         ..headers.addAll(headers)
         ..files.add(multipartFile)
-        ..fields['cacheControl'] = fileOptions.cacheControl
+        ..headers['cacheControl'] = fileOptions.cacheControl
         ..headers['x-upsert'] = fileOptions.upsert.toString();
 
       final streamedResponse = await request.send();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixed a bug where `cachConntrol` value was sent as request body rather than request header, and therefore users were not able to set cacheControl value to their custom value. 

## What is the current behavior?

`cacheControl` was sent as request body

## What is the new behavior?

`cacheControl` is sent as request header
