### PR TITLE
Set application/octet-stream as default mime-type

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -43,7 +43,7 @@ class Fetch {
   MediaType? _parseMediaType(String path) {
     try {
       final mime = lookupMimeType(path);
-      return MediaType.parse(mime ?? '');
+      return MediaType.parse(mime ?? 'application/octet-stream');
     } catch (error) {
       rethrow;
     }


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the mime type is not found by filename extension (such as `file.test` then the application will throw:

```Invalid media type: expected /[^()<>@,;:"\\/[\]?={} \t\x00-\x1F\x7F]+/.```

## What is the new behavior?

I'm proposing we set `application/octet-stream`  as the default mime type if we can't figure out the extension..
