### PR TITLE
chore: updated Github action to use official dart-lang action to setup dart

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Test
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   push:
     branches: [main]
@@ -18,6 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ["12"]
+        sdk: [stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 
@@ -26,7 +23,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Dart
-        uses: cedx/setup-dart@v2
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: pub get

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }}
+    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }} / SDK ${{ matrix.sdk }}
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/example/main.dart
+++ b/example/main.dart
@@ -7,14 +7,20 @@ Future<void> main() async {
   const supabaseUrl = '';
   const supabaseKey = '';
   final client = SupabaseStorageClient(
-      '$supabaseUrl/storage/v1', {'Authorization': 'Bearer $supabaseKey'});
+    '$supabaseUrl/storage/v1',
+    {
+      'Authorization': 'Bearer $supabaseKey',
+    },
+  );
 
   // Upload binary file
   final List<int> listBytes = 'Hello world'.codeUnits;
   final Uint8List fileData = Uint8List.fromList(listBytes);
   final uploadBinaryResponse = await client.from('public').uploadBinary(
-      'binaryExample.txt', fileData,
-      fileOptions: const FileOptions(upsert: true));
+        'binaryExample.txt',
+        fileData,
+        fileOptions: const FileOptions(upsert: true),
+      );
   print('upload binary response : ${uploadBinaryResponse.data}');
 
   // Upload file to bucket "public"

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -168,42 +168,63 @@ class Fetch {
     return _handleRequest('GET', url, {}, options);
   }
 
-  Future<StorageResponse> post(String url, dynamic body,
-      {FetchOptions? options}) async {
+  Future<StorageResponse> post(
+    String url,
+    dynamic body, {
+    FetchOptions? options,
+  }) async {
     return _handleRequest('POST', url, body, options);
   }
 
-  Future<StorageResponse> put(String url, dynamic body,
-      {FetchOptions? options}) async {
+  Future<StorageResponse> put(
+    String url,
+    dynamic body, {
+    FetchOptions? options,
+  }) async {
     return _handleRequest('PUT', url, body, options);
   }
 
-  Future<StorageResponse> delete(String url, dynamic body,
-      {FetchOptions? options}) async {
+  Future<StorageResponse> delete(
+    String url,
+    dynamic body, {
+    FetchOptions? options,
+  }) async {
     return _handleRequest('DELETE', url, body, options);
   }
 
   Future<StorageResponse> postFile(
-      String url, File file, FileOptions fileOptions,
-      {FetchOptions? options}) async {
+    String url,
+    File file,
+    FileOptions fileOptions, {
+    FetchOptions? options,
+  }) async {
     return _handleMultipartRequest('POST', url, file, fileOptions, options);
   }
 
   Future<StorageResponse> putFile(
-      String url, File file, FileOptions fileOptions,
-      {FetchOptions? options}) async {
+    String url,
+    File file,
+    FileOptions fileOptions, {
+    FetchOptions? options,
+  }) async {
     return _handleMultipartRequest('PUT', url, file, fileOptions, options);
   }
 
   Future<StorageResponse> postBinaryFile(
-      String url, Uint8List data, FileOptions fileOptions,
-      {FetchOptions? options}) async {
+    String url,
+    Uint8List data,
+    FileOptions fileOptions, {
+    FetchOptions? options,
+  }) async {
     return _handleBinaryFileRequest('POST', url, data, fileOptions, options);
   }
 
   Future<StorageResponse> putBinaryFile(
-      String url, Uint8List data, FileOptions fileOptions,
-      {FetchOptions? options}) async {
+    String url,
+    Uint8List data,
+    FileOptions fileOptions, {
+    FetchOptions? options,
+  }) async {
     return _handleBinaryFileRequest('PUT', url, data, fileOptions, options);
   }
 }

--- a/lib/src/storage_bucket_api.dart
+++ b/lib/src/storage_bucket_api.dart
@@ -16,7 +16,10 @@ class StorageBucketApi {
         return StorageResponse(error: response.error);
       } else {
         final buckets = List<Bucket>.from(
-            (response.data as List).map((value) => Bucket.fromJson(value)));
+          (response.data as List).map(
+            (value) => Bucket.fromJson(value),
+          ),
+        );
         return StorageResponse<List<Bucket>>(data: buckets);
       }
     } catch (e) {
@@ -45,9 +48,10 @@ class StorageBucketApi {
   ///
   /// [id] A unique identifier for the bucket you are creating.
   /// [bucketOptions] A parameter to optionally make the bucket public.
-  Future<StorageResponse<String>> createBucket(String id,
-      [BucketOptions bucketOptions =
-          const BucketOptions(public: false)]) async {
+  Future<StorageResponse<String>> createBucket(
+    String id, [
+    BucketOptions bucketOptions = const BucketOptions(public: false),
+  ]) async {
     try {
       final FetchOptions options = FetchOptions(headers: headers);
       final response = await fetch.post(
@@ -71,7 +75,9 @@ class StorageBucketApi {
   /// [id] A unique identifier for the bucket you are creating.
   /// [bucketOptions] A parameter to set the publicity of the bucket.
   Future<StorageResponse<String>> updateBucket(
-      String id, BucketOptions bucketOptions) async {
+    String id,
+    BucketOptions bucketOptions,
+  ) async {
     try {
       final FetchOptions options = FetchOptions(headers: headers);
       final response = await fetch.put(
@@ -102,7 +108,8 @@ class StorageBucketApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: response.data['message'] as String);
+          data: response.data['message'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));
@@ -122,7 +129,8 @@ class StorageBucketApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: response.data['message'] as String);
+          data: response.data['message'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -32,8 +32,11 @@ class StorageFileApi {
   /// [path] The relative file path including the bucket ID. Should be of the format `bucket/folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
   /// [file] The File object to be stored in the bucket.
   /// [fileOptions] HTTP headers. For example `cacheControl`
-  Future<StorageResponse<String>> upload(String path, File file,
-      {FileOptions? fileOptions}) async {
+  Future<StorageResponse<String>> upload(
+    String path,
+    File file, {
+    FileOptions? fileOptions,
+  }) async {
     try {
       final _path = _getFinalPath(path);
       final response = await fetch.postFile(
@@ -47,7 +50,8 @@ class StorageFileApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: (response.data as Map)['Key'] as String);
+          data: (response.data as Map)['Key'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));
@@ -59,8 +63,11 @@ class StorageFileApi {
   /// [path] The relative file path including the bucket ID. Should be of the format `bucket/folder/subfolder/filename.png`. The bucket must already exist before attempting to upload.
   /// [data] The binary file data to be stored in the bucket.
   /// [fileOptions] HTTP headers. For example `cacheControl`
-  Future<StorageResponse<String>> uploadBinary(String path, Uint8List data,
-      {FileOptions? fileOptions}) async {
+  Future<StorageResponse<String>> uploadBinary(
+    String path,
+    Uint8List data, {
+    FileOptions? fileOptions,
+  }) async {
     try {
       final _path = _getFinalPath(path);
       final response = await fetch.postBinaryFile(
@@ -74,7 +81,8 @@ class StorageFileApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: (response.data as Map)['Key'] as String);
+          data: (response.data as Map)['Key'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));
@@ -86,8 +94,11 @@ class StorageFileApi {
   /// [path] The relative file path including the bucket ID. Should be of the format `bucket/folder/subfolder`. The bucket already exist before attempting to upload.
   /// [file] The file object to be stored in the bucket.
   /// [fileOptions] HTTP headers. For example `cacheControl`
-  Future<StorageResponse<String>> update(String path, File file,
-      {FileOptions? fileOptions}) async {
+  Future<StorageResponse<String>> update(
+    String path,
+    File file, {
+    FileOptions? fileOptions,
+  }) async {
     try {
       final _path = _getFinalPath(path);
       final response = await fetch.putFile(
@@ -112,8 +123,11 @@ class StorageFileApi {
   /// [path] The relative file path including the bucket ID. Should be of the format `bucket/folder/subfolder`. The bucket already exist before attempting to upload.
   /// [data] The binary file data to be stored in the bucket.
   /// [fileOptions] HTTP headers. For example `cacheControl`
-  Future<StorageResponse<String>> updateBinary(String path, Uint8List data,
-      {FileOptions? fileOptions}) async {
+  Future<StorageResponse<String>> updateBinary(
+    String path,
+    Uint8List data, {
+    FileOptions? fileOptions,
+  }) async {
     try {
       final _path = _getFinalPath(path);
       final response = await fetch.putBinaryFile(
@@ -127,7 +141,8 @@ class StorageFileApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: (response.data as Map)['Key'] as String);
+          data: (response.data as Map)['Key'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));
@@ -154,7 +169,8 @@ class StorageFileApi {
         return StorageResponse(error: response.error);
       } else {
         return StorageResponse<String>(
-            data: response.data['message'] as String);
+          data: response.data['message'] as String,
+        );
       }
     } catch (e) {
       return StorageResponse(error: StorageError(e.toString()));
@@ -166,7 +182,9 @@ class StorageFileApi {
   /// [path] The file path to be downloaded, including the current file name. For example `folder/image.png`.
   /// [expiresIn] The number of seconds until the signed URL expires. For example, `60` for a URL which is valid for one minute.
   Future<StorageResponse<String>> createSignedUrl(
-      String path, int expiresIn) async {
+    String path,
+    int expiresIn,
+  ) async {
     try {
       final _path = _getFinalPath(path);
       final options = FetchOptions(headers: headers);
@@ -224,13 +242,18 @@ class StorageFileApi {
     try {
       final options = FetchOptions(headers: headers);
       final response = await fetch.delete(
-          '$url/object/$bucketId', {'prefixes': paths},
-          options: options);
+        '$url/object/$bucketId',
+        {'prefixes': paths},
+        options: options,
+      );
       if (response.hasError) {
         return StorageResponse(error: response.error);
       } else {
         final fileObjects = List<FileObject>.from(
-            (response.data as List).map((item) => FileObject.fromJson(item)));
+          (response.data as List).map(
+            (item) => FileObject.fromJson(item),
+          ),
+        );
         return StorageResponse<List<FileObject>>(data: fileObjects);
       }
     } catch (e) {
@@ -241,8 +264,10 @@ class StorageFileApi {
   /// Lists all the files within a bucket.
   /// [path] The folder path.
   /// [searchOptions] includes `limit`, `offset`, and `sortBy`.
-  Future<StorageResponse<List<FileObject>>> list(
-      {String? path, SearchOptions? searchOptions}) async {
+  Future<StorageResponse<List<FileObject>>> list({
+    String? path,
+    SearchOptions? searchOptions,
+  }) async {
     try {
       final Map<String, dynamic> body = {
         'prefix': path ?? '',
@@ -256,13 +281,19 @@ class StorageFileApi {
         },
       };
       final options = FetchOptions(headers: headers);
-      final response = await fetch.post('$url/object/list/$bucketId', body,
-          options: options);
+      final response = await fetch.post(
+        '$url/object/list/$bucketId',
+        body,
+        options: options,
+      );
       if (response.hasError) {
         return StorageResponse(error: response.error);
       } else {
         final fileObjects = List<FileObject>.from(
-            (response.data as List).map((item) => FileObject.fromJson(item)));
+          (response.data as List).map(
+            (item) => FileObject.fromJson(item),
+          ),
+        );
         return StorageResponse<List<FileObject>>(data: fileObjects);
       }
     } catch (e) {

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -45,8 +45,9 @@ void main() {
   group('client', () {
     setUp(() {
       // init SupabaseClient with test url & test key
-      client = SupabaseStorageClient(
-          '$supabaseUrl/storage/v1', {'Authorization': 'Bearer $supabaseKey'});
+      client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
+        'Authorization': 'Bearer $supabaseKey',
+      });
 
       // Use mocked version for `fetch`, to prevent actual http calls.
       fetch = MockFetch();
@@ -63,8 +64,10 @@ void main() {
 
     test('should list buckets', () async {
       when(() => fetch.get(bucketUrl, options: mockFetchOptions)).thenAnswer(
-          (_) => Future.value(
-              StorageResponse(data: [testBucketJson, testBucketJson])));
+        (_) => Future.value(
+          StorageResponse(data: [testBucketJson, testBucketJson]),
+        ),
+      );
 
       final response = await client.listBuckets();
       expect(response.error, isNull);
@@ -79,8 +82,15 @@ void main() {
         'public': false
       };
       when(() => fetch.post(bucketUrl, requestBody, options: mockFetchOptions))
-          .thenAnswer((_) =>
-              Future.value(StorageResponse(data: {'name': 'test_bucket'})));
+          .thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: {
+              'name': 'test_bucket',
+            },
+          ),
+        ),
+      );
 
       final response = await client.createBucket(testBucketId);
       expect(response.error, isNull);
@@ -90,10 +100,18 @@ void main() {
 
     test('should get bucket', () async {
       const testBucketId = 'test_bucket';
-      when(() =>
-              fetch.get('$bucketUrl/$testBucketId', options: mockFetchOptions))
-          .thenAnswer(
-              (_) => Future.value(StorageResponse(data: testBucketJson)));
+      when(
+        () => fetch.get(
+          '$bucketUrl/$testBucketId',
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: testBucketJson,
+          ),
+        ),
+      );
 
       final response = await client.getBucket(testBucketId);
       expect(response.error, isNull);
@@ -104,10 +122,21 @@ void main() {
 
     test('should empty bucket', () async {
       const testBucketId = 'test_bucket';
-      when(() =>
-          fetch.post('$bucketUrl/$testBucketId/empty', {},
-              options: mockFetchOptions)).thenAnswer(
-          (_) => Future.value(StorageResponse(data: {'message': 'Emptied'})));
+      when(
+        () => fetch.post(
+          '$bucketUrl/$testBucketId/empty',
+          {},
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: {
+              'message': 'Emptied',
+            },
+          ),
+        ),
+      );
 
       final response = await client.emptyBucket(testBucketId);
       expect(response.error, isNull);
@@ -116,10 +145,15 @@ void main() {
 
     test('should delete bucket', () async {
       const testBucketId = 'test_bucket';
-      when(() =>
-          fetch.delete('$bucketUrl/$testBucketId', {},
-              options: mockFetchOptions)).thenAnswer(
-          (_) => Future.value(StorageResponse(data: {'message': 'Deleted'})));
+      when(
+        () => fetch.delete(
+          '$bucketUrl/$testBucketId',
+          {},
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(StorageResponse(data: {'message': 'Deleted'})),
+      );
 
       final response = await client.deleteBucket(testBucketId);
       expect(response.error, isNull);
@@ -130,10 +164,16 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('File content');
 
-      when(() =>
-          fetch.postFile('$objectUrl/public/a.txt', file, mockFileOptions,
-              options: mockFetchOptions)).thenAnswer(
-          (_) => Future.value(StorageResponse(data: {'Key': 'public/a.txt'})));
+      when(
+        () => fetch.postFile(
+          '$objectUrl/public/a.txt',
+          file,
+          mockFileOptions,
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(StorageResponse(data: {'Key': 'public/a.txt'})),
+      );
 
       final response = await client.from('public').upload('a.txt', file);
       expect(response.error, isNull);
@@ -145,10 +185,16 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('Updated content');
 
-      when(() =>
-          fetch.putFile('$objectUrl/public/a.txt', file, mockFileOptions,
-              options: mockFetchOptions)).thenAnswer(
-          (_) => Future.value(StorageResponse(data: {'Key': 'public/a.txt'})));
+      when(
+        () => fetch.putFile(
+          '$objectUrl/public/a.txt',
+          file,
+          mockFileOptions,
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(StorageResponse(data: {'Key': 'public/a.txt'})),
+      );
 
       final response = await client.from('public').update('a.txt', file);
       expect(response.error, isNull);
@@ -162,10 +208,15 @@ void main() {
         'sourceKey': 'a.txt',
         'destinationKey': 'b.txt',
       };
-      when(() => fetch.post('$objectUrl/move', requestBody,
-              options: mockFetchOptions))
-          .thenAnswer(
-              (_) => Future.value(StorageResponse(data: {'message': 'Move'})));
+      when(
+        () => fetch.post(
+          '$objectUrl/move',
+          requestBody,
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(StorageResponse(data: {'message': 'Move'})),
+      );
 
       final response = await client.from('public').move('a.txt', 'b.txt');
       expect(response.error, isNull);
@@ -173,10 +224,15 @@ void main() {
     });
 
     test('should createSignedUrl file', () async {
-      when(() => fetch.post('$objectUrl/sign/public/b.txt', {'expiresIn': 60},
-              options: mockFetchOptions))
-          .thenAnswer(
-              (_) => Future.value(StorageResponse(data: {'signedURL': 'url'})));
+      when(
+        () => fetch.post(
+          '$objectUrl/sign/public/b.txt',
+          {'expiresIn': 60},
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(StorageResponse(data: {'signedURL': 'url'})),
+      );
 
       final response = await client.from('public').createSignedUrl('b.txt', 60);
       expect(response.error, isNull);
@@ -184,10 +240,19 @@ void main() {
     });
 
     test('should list files', () async {
-      when(() => fetch.post('$objectUrl/list/public', any(),
-              options: mockFetchOptions))
-          .thenAnswer((_) => Future.value(
-              StorageResponse(data: [testFileObjectJson, testFileObjectJson])));
+      when(
+        () => fetch.post(
+          '$objectUrl/list/public',
+          any(),
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: [testFileObjectJson, testFileObjectJson],
+          ),
+        ),
+      );
 
       final response = await client.from('public').list();
       expect(response.error, isNull);
@@ -199,10 +264,18 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('Updated content');
 
-      when(() =>
-              fetch.get('$objectUrl/public/b.txt', options: mockFetchOptions))
-          .thenAnswer((_) =>
-              Future.value(StorageResponse(data: file.readAsBytesSync())));
+      when(
+        () => fetch.get(
+          '$objectUrl/public/b.txt',
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: file.readAsBytesSync(),
+          ),
+        ),
+      );
 
       final response = await client.from('public').download('b.txt');
       expect(response.error, isNull);
@@ -220,10 +293,19 @@ void main() {
       final requestBody = {
         'prefixes': ['a.txt', 'b.txt']
       };
-      when(() => fetch.delete('$objectUrl/public', requestBody,
-              options: mockFetchOptions))
-          .thenAnswer((_) => Future.value(
-              StorageResponse(data: [testFileObjectJson, testFileObjectJson])));
+      when(
+        () => fetch.delete(
+          '$objectUrl/public',
+          requestBody,
+          options: mockFetchOptions,
+        ),
+      ).thenAnswer(
+        (_) => Future.value(
+          StorageResponse(
+            data: [testFileObjectJson, testFileObjectJson],
+          ),
+        ),
+      );
 
       final response = await client.from('public').remove(['a.txt', 'b.txt']);
       expect(response.error, isNull);
@@ -235,7 +317,11 @@ void main() {
   group('header', () {
     test('X-Client-Info header is set', () {
       client = SupabaseStorageClient(
-          '$supabaseUrl/storage/v1', {'Authorization': 'Bearer $supabaseKey'});
+        '$supabaseUrl/storage/v1',
+        {
+          'Authorization': 'Bearer $supabaseKey',
+        },
+      );
 
       expect(client.headers['X-Client-Info']!.split('/').first, 'storage-dart');
     });

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -14,8 +14,9 @@ void main() {
 
   setUp(() {
     // init SupabaseClient with test url & test key
-    client = SupabaseStorageClient(
-        storageUrl, {'Authorization': 'Bearer $storageKey'});
+    client = SupabaseStorageClient(storageUrl, {
+      'Authorization': 'Bearer $storageKey',
+    });
 
     // Register default mock values (used by mocktail)
     registerFallbackValue<FileOptions>(const FileOptions());
@@ -46,14 +47,18 @@ void main() {
   test('Create new public bucket', () async {
     const newPublicBucketName = 'my-new-public-bucket';
     await client.createBucket(
-        newPublicBucketName, const BucketOptions(public: true));
+      newPublicBucketName,
+      const BucketOptions(public: true),
+    );
     final response = await client.getBucket(newPublicBucketName);
     expect(response.data!.public, true);
   });
 
   test('update bucket', () async {
     final updateRes = await client.updateBucket(
-        newBucketName, const BucketOptions(public: true));
+      newBucketName,
+      const BucketOptions(public: true),
+    );
     expect(updateRes.error, isNull);
     expect(updateRes.data, isA<String>());
     final getRes = await client.getBucket(newBucketName);


### PR DESCRIPTION
## What kind of change does this PR introduce?

The [Github action we used to use for Dart language](https://github.com/cedx/setup-dart) is now deprecated, and there is a [one published by the official dart language team](https://github.com/marketplace/actions/setup-dart-sdk), so using that one instead of the current one. 

This PR will include any analysis error fix that is raised with the newest stable dart language `2.14.0`. 

## What is the current behavior?

Using a deprecated Github Action.

## What is the new behavior?

Using Github Action published by the official dart lang team and also testing stable, beta, dev version of dart language. 
