### PR TITLE
fix: move StorageError/Response to types

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -9,32 +9,6 @@ import 'package:universal_io/io.dart';
 
 Fetch fetch = Fetch();
 
-class StorageError {
-  final String message;
-  final String? error;
-  final String? statusCode;
-
-  StorageError(this.message, {this.error, this.statusCode});
-
-  StorageError.fromJson(dynamic json)
-      : assert(json is Map<String, dynamic>),
-        message = json['message'] as String,
-        error = json['error'] as String?,
-        statusCode = json['statusCode'] as String?;
-
-  @override
-  String toString() => message;
-}
-
-class StorageResponse<T> {
-  final StorageError? error;
-  final T? data;
-
-  StorageResponse({this.data, this.error});
-
-  bool get hasError => error != null;
-}
-
 class Fetch {
   bool _isSuccessStatusCode(int code) {
     return code >= 200 && code <= 299;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -111,3 +111,29 @@ class Metadata {
 
   final String? name;
 }
+
+class StorageError {
+  final String message;
+  final String? error;
+  final String? statusCode;
+
+  StorageError(this.message, {this.error, this.statusCode});
+
+  StorageError.fromJson(dynamic json)
+      : assert(json is Map<String, dynamic>),
+        message = json['message'] as String,
+        error = json['error'] as String?,
+        statusCode = json['statusCode'] as String?;
+
+  @override
+  String toString() => message;
+}
+
+class StorageResponse<T> {
+  final StorageError? error;
+  final T? data;
+
+  StorageResponse({this.data, this.error});
+
+  bool get hasError => error != null;
+}


### PR DESCRIPTION
Enables the dev to use these types, because they are now exported.

## What kind of change does this PR introduce?

Moves `StorageError` and `StorageResponse` from `fetch.dart` to `types.dart`. 

## What is the current behavior?

To use these types in your code you need to import `package:storage_client/src/fetch.dart`, but importing from `src` is not [recommended](https://dart-lang.github.io/linter/lints/implementation_imports.html).

## What is the new behavior?
Because `types.dart` is exported, you can use it without additional imports.
