### PR TITLE
chore: publish version 0.0.5+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.5+1]
+
+- fix: Move `StorageError` to `types.dart`
+
 ## [0.0.5]
 
 - fix: Set `X-Client-Info` header

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.0.5';
+const version = '0.0.5+1';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage.
-version: 0.0.5
+version: 0.0.5+1
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/storage-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bumps the version from `0.0.5` to `0.0.5+1`. 

I was wrong and you were @bdlukaa when we had a discussion last time [here](https://github.com/supabase/supabase-dart/pull/53#issuecomment-922277890). I was not aware of the proper versioning prior to version `1.0.0` and I should have done my research more throughly. For that I apologize. 

From [Dart Package Versioning article](https://dart.dev/tools/pub/versioning)
>Although semantic versioning doesn’t promise any compatibility between versions prior to 1.0.0, the Dart community convention is to treat those versions semantically as well. The interpretation of each number is just shifted down one slot: going from 0.1.2 to 0.2.0 indicates a breaking change, going to 0.1.3 indicates a new feature, and going to 0.1.2+1 indicates a change that doesn’t affect the public API. For simplicity’s sake, avoid using + after the version reaches 1.0.0.

## What is the current behavior?

Version is 0.0.5

## What is the new behavior?

New version is 0.0.5+1

## Additional context

After merging this one, I plan to publish a new version of `supabase_dart` and `supabase_flutter`. 
