### PR TITLE
feat: set custom mime/Content-Type

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -68,11 +68,14 @@ class Fetch {
   ) async {
     try {
       final headers = options?.headers ?? {};
+      final contentType = fileOptions.mime != null
+          ? MediaType.parse(fileOptions.mime!)
+          : _parseMediaType(file.path);
       final multipartFile = http.MultipartFile.fromBytes(
         '',
         file.readAsBytesSync(),
         filename: file.path,
-        contentType: _parseMediaType(file.path),
+        contentType: contentType,
       );
       final request = http.MultipartRequest(method, Uri.parse(url))
         ..headers.addAll(headers)
@@ -101,7 +104,8 @@ class Fetch {
         data,
         // request fails with null filename so set it empty instead.
         filename: '',
-        contentType: _parseMediaType(url),
+        contentType:
+            MediaType.parse(fileOptions.mime ?? 'application/octet-stream'),
       );
       final request = http.MultipartRequest(method, Uri.parse(url))
         ..headers.addAll(headers)

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -77,10 +77,20 @@ class BucketOptions {
 }
 
 class FileOptions {
-  const FileOptions({this.cacheControl = '3600', this.upsert = false});
+  const FileOptions({
+    this.cacheControl = '3600',
+    this.upsert = false,
+    this.mime,
+  });
 
   final String cacheControl;
   final bool upsert;
+
+  /// Used as Content-Type
+  /// Gets parsed with [MediaType.parse(mime)]
+  ///
+  /// Throws a FormatError if the media type is invalid.
+  final String? mime;
 }
 
 class SearchOptions {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds `mime` to `FileOptions`, which enables the dev to set custom Content-Type

## What is the current behavior?

Binary upload/update misses custom Content-Type, which causes missing preview in for example Supabase dashboard

## What is the new behavior?

The dev can specify a custom Content-Type.

## Additional context

The Content-Type in `_handleBinaryFileRequest` was previously gotten from `_parseMediaType(url)`, which I think makes no sense, because the url has nothing to do with the new file itself.
