### PR TITLE
chore: publish version 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.0.6]
+
+- feat: set custom mime/Content-Type from `FileOptions`
+- fix: Move `StorageError` to `types.dart`
+
 ## [0.0.5]
 
 - fix: Set `X-Client-Info` header

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '0.0.5';
+const version = '0.0.6';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage.
-version: 0.0.5
+version: 0.0.6
 homepage: 'https://supabase.io'
 repository: 'https://github.com/supabase/storage-dart'
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Publishes a new version for storage-dart

## What is the current behavior?

Version is 0.0.5

## What is the new behavior?

Version is 0.0.6

## Additional context

Closed [this](https://github.com/supabase/storage-dart/pull/17) issue because there was additional update. 
