### PR TITLE
Fix/move

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -15,12 +15,8 @@ class Fetch {
   }
 
   MediaType? _parseMediaType(String path) {
-    try {
-      final mime = lookupMimeType(path);
-      return MediaType.parse(mime ?? 'application/octet-stream');
-    } catch (error) {
-      rethrow;
-    }
+    final mime = lookupMimeType(path);
+    return MediaType.parse(mime ?? 'application/octet-stream');
   }
 
   StorageError _handleError(dynamic error) {

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -159,7 +159,7 @@ class StorageFileApi {
       final response = await fetch.post(
         '$url/object/move',
         {
-          'bucketName': bucketId,
+          'bucketId': bucketId,
           'sourceKey': fromPath,
           'destinationKey': toPath,
         },

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -136,7 +136,9 @@ class StorageError {
         statusCode = json['statusCode'] as String?;
 
   @override
-  String toString() => message;
+  String toString() {
+    return 'StorageError(message: $message, statusCode: $statusCode, error: $error)';
+  }
 }
 
 class StorageResponse<T> {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Moving an object doesn't work. Instead of the parameter `buckeId` the body parameter `bucketName` was given. [Storage api](https://supabase.github.io/storage-api/#/object/post_object_move)

## What is the new behavior?

Moving works.

## Additional context

In addition, I changed `StorageError.toString()` to align it to `PostgrestError.toString()` [link](https://github.com/supabase/postgrest-dart/blob/master/lib/src/postgrest_error.dart#L30)
