### PR TITLE
refactor: add statuscode to StorageError

### DIFF
--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -25,10 +25,16 @@ class Fetch {
         final data = json.decode(error.body) as Map<String, dynamic>;
         return StorageError.fromJson(data);
       } on FormatException catch (_) {
-        return StorageError(error.body);
+        return StorageError(
+          error.body,
+          statusCode: error.statusCode.toString(),
+        );
       }
     } else {
-      return StorageError(error.toString());
+      return StorageError(
+        error.toString(),
+        statusCode: error.runtimeType.toString(),
+      );
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Idk, not really a bug fix, rather refactoring.

## What is the current behavior?

When the json decoding and parsing fails, a `StorageError` is created with the whole body as error, but without a status code. In addition, I added the `runtimeType` as status code, when it's not `http.Response` to align it to [postgrest-dart](https://github.com/supabase/postgrest-dart/blob/c09bb09883bd69d956019dc2c5e178f19bdef5c3/lib/src/postgrest_builder.dart#L91). I'm checking `statuscode` to check for no internet connection. And I don't want to use `message.startsWith("SocketException")`

## What is the new behavior?
Adds the status code.

## Additional context

I'm in general confused by the difference between `error` and `message`.
