### PR TITLE
feat: can retry file upload failure when offline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [2.14.0, stable, beta, dev]
+        sdk: [2.15.0, stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 

--- a/a.txt
+++ b/a.txt
@@ -1,0 +1,1 @@
+File content

--- a/a.txt
+++ b/a.txt
@@ -1,1 +1,0 @@
-File content

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -239,7 +239,13 @@ class Fetch {
     required int maxAttempts,
   }) async {
     return _handleBinaryFileRequest(
-        'POST', url, data, fileOptions, options, maxAttempts);
+      'POST',
+      url,
+      data,
+      fileOptions,
+      options,
+      maxAttempts,
+    );
   }
 
   Future<dynamic> putBinaryFile(
@@ -250,6 +256,12 @@ class Fetch {
     required int maxAttempts,
   }) async {
     return _handleBinaryFileRequest(
-        'PUT', url, data, fileOptions, options, maxAttempts);
+      'PUT',
+      url,
+      data,
+      fileOptions,
+      options,
+      maxAttempts,
+    );
   }
 }

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -78,7 +78,7 @@ class Fetch {
     FileOptions fileOptions,
     FetchOptions? options,
     int retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -107,7 +107,7 @@ class Fetch {
         }
       },
       retryIf: (error) =>
-          abortController?.aborted != true &&
+          retryController?.cancelled != true &&
           (error is SocketException || error is TimeoutException),
     );
 
@@ -121,7 +121,7 @@ class Fetch {
     FileOptions fileOptions,
     FetchOptions? options,
     int retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -151,7 +151,7 @@ class Fetch {
         }
       },
       retryIf: (error) =>
-          abortController?.aborted != true &&
+          retryController?.cancelled != true &&
           (error is SocketException || error is TimeoutException),
     );
 
@@ -209,10 +209,10 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int retryAttempts,
-    required StorageAbortController? abortController,
+    required StorageRetryController? retryController,
   }) async {
     return _handleMultipartRequest('POST', url, file, fileOptions, options,
-        retryAttempts, abortController);
+        retryAttempts, retryController);
   }
 
   Future<dynamic> putFile(
@@ -221,7 +221,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int retryAttempts,
-    required StorageAbortController? abortController,
+    required StorageRetryController? retryController,
   }) async {
     return _handleMultipartRequest(
       'PUT',
@@ -230,7 +230,7 @@ class Fetch {
       fileOptions,
       options,
       retryAttempts,
-      abortController,
+      retryController,
     );
   }
 
@@ -240,7 +240,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int retryAttempts,
-    required StorageAbortController? abortController,
+    required StorageRetryController? retryController,
   }) async {
     return _handleBinaryFileRequest(
       'POST',
@@ -249,7 +249,7 @@ class Fetch {
       fileOptions,
       options,
       retryAttempts,
-      abortController,
+      retryController,
     );
   }
 
@@ -259,7 +259,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int retryAttempts,
-    required StorageAbortController? abortController,
+    required StorageRetryController? retryController,
   }) async {
     return _handleBinaryFileRequest(
       'PUT',
@@ -268,7 +268,7 @@ class Fetch {
       fileOptions,
       options,
       retryAttempts,
-      abortController,
+      retryController,
     );
   }
 }

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -78,6 +78,7 @@ class Fetch {
     FileOptions fileOptions,
     FetchOptions? options,
     int maxAttempts,
+    StorageAbortController? abortSignal,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -105,7 +106,9 @@ class Fetch {
           return request.send();
         }
       },
-      retryIf: (error) => error is SocketException || error is TimeoutException,
+      retryIf: (error) =>
+          abortSignal?.aborted != true &&
+          (error is SocketException || error is TimeoutException),
     );
 
     return _handleResponse(streamedResponse, options);
@@ -118,6 +121,7 @@ class Fetch {
     FileOptions fileOptions,
     FetchOptions? options,
     int maxAttempts,
+    StorageAbortController? abortSignal,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -146,7 +150,9 @@ class Fetch {
           return request.send();
         }
       },
-      retryIf: (error) => error is SocketException || error is TimeoutException,
+      retryIf: (error) =>
+          abortSignal?.aborted != true &&
+          (error is SocketException || error is TimeoutException),
     );
 
     return _handleResponse(streamedResponse, options);
@@ -203,15 +209,10 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int maxAttempts,
+    required StorageAbortController? abortController,
   }) async {
     return _handleMultipartRequest(
-      'POST',
-      url,
-      file,
-      fileOptions,
-      options,
-      maxAttempts,
-    );
+        'POST', url, file, fileOptions, options, maxAttempts, abortController);
   }
 
   Future<dynamic> putFile(
@@ -220,6 +221,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int maxAttempts,
+    required StorageAbortController? abortController,
   }) async {
     return _handleMultipartRequest(
       'PUT',
@@ -228,6 +230,7 @@ class Fetch {
       fileOptions,
       options,
       maxAttempts,
+      abortController,
     );
   }
 
@@ -237,6 +240,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int maxAttempts,
+    required StorageAbortController? abortController,
   }) async {
     return _handleBinaryFileRequest(
       'POST',
@@ -245,6 +249,7 @@ class Fetch {
       fileOptions,
       options,
       maxAttempts,
+      abortController,
     );
   }
 
@@ -254,6 +259,7 @@ class Fetch {
     FileOptions fileOptions, {
     FetchOptions? options,
     required int maxAttempts,
+    required StorageAbortController? abortController,
   }) async {
     return _handleBinaryFileRequest(
       'PUT',
@@ -262,6 +268,7 @@ class Fetch {
       fileOptions,
       options,
       maxAttempts,
+      abortController,
     );
   }
 }

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -77,8 +77,8 @@ class Fetch {
     File file,
     FileOptions fileOptions,
     FetchOptions? options,
-    int maxAttempts,
-    StorageAbortController? abortSignal,
+    int retryAttempts,
+    StorageAbortController? abortController,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -97,7 +97,7 @@ class Fetch {
       ..headers['x-upsert'] = fileOptions.upsert.toString();
 
     final http.StreamedResponse streamedResponse;
-    final r = RetryOptions(maxAttempts: maxAttempts);
+    final r = RetryOptions(maxAttempts: (retryAttempts + 1));
     streamedResponse = await r.retry<http.StreamedResponse>(
       () async {
         if (httpClient != null) {
@@ -107,7 +107,7 @@ class Fetch {
         }
       },
       retryIf: (error) =>
-          abortSignal?.aborted != true &&
+          abortController?.aborted != true &&
           (error is SocketException || error is TimeoutException),
     );
 
@@ -120,8 +120,8 @@ class Fetch {
     Uint8List data,
     FileOptions fileOptions,
     FetchOptions? options,
-    int maxAttempts,
-    StorageAbortController? abortSignal,
+    int retryAttempts,
+    StorageAbortController? abortController,
   ) async {
     final headers = options?.headers ?? {};
     final contentType = fileOptions.contentType != null
@@ -141,7 +141,7 @@ class Fetch {
       ..headers['x-upsert'] = fileOptions.upsert.toString();
 
     final http.StreamedResponse streamedResponse;
-    final r = RetryOptions(maxAttempts: maxAttempts);
+    final r = RetryOptions(maxAttempts: (retryAttempts + 1));
     streamedResponse = await r.retry<http.StreamedResponse>(
       () async {
         if (httpClient != null) {
@@ -151,7 +151,7 @@ class Fetch {
         }
       },
       retryIf: (error) =>
-          abortSignal?.aborted != true &&
+          abortController?.aborted != true &&
           (error is SocketException || error is TimeoutException),
     );
 
@@ -208,11 +208,11 @@ class Fetch {
     File file,
     FileOptions fileOptions, {
     FetchOptions? options,
-    required int maxAttempts,
+    required int retryAttempts,
     required StorageAbortController? abortController,
   }) async {
-    return _handleMultipartRequest(
-        'POST', url, file, fileOptions, options, maxAttempts, abortController);
+    return _handleMultipartRequest('POST', url, file, fileOptions, options,
+        retryAttempts, abortController);
   }
 
   Future<dynamic> putFile(
@@ -220,7 +220,7 @@ class Fetch {
     File file,
     FileOptions fileOptions, {
     FetchOptions? options,
-    required int maxAttempts,
+    required int retryAttempts,
     required StorageAbortController? abortController,
   }) async {
     return _handleMultipartRequest(
@@ -229,7 +229,7 @@ class Fetch {
       file,
       fileOptions,
       options,
-      maxAttempts,
+      retryAttempts,
       abortController,
     );
   }
@@ -239,7 +239,7 @@ class Fetch {
     Uint8List data,
     FileOptions fileOptions, {
     FetchOptions? options,
-    required int maxAttempts,
+    required int retryAttempts,
     required StorageAbortController? abortController,
   }) async {
     return _handleBinaryFileRequest(
@@ -248,7 +248,7 @@ class Fetch {
       data,
       fileOptions,
       options,
-      maxAttempts,
+      retryAttempts,
       abortController,
     );
   }
@@ -258,7 +258,7 @@ class Fetch {
     Uint8List data,
     FileOptions fileOptions, {
     FetchOptions? options,
-    required int maxAttempts,
+    required int retryAttempts,
     required StorageAbortController? abortController,
   }) async {
     return _handleBinaryFileRequest(
@@ -267,7 +267,7 @@ class Fetch {
       data,
       fileOptions,
       options,
-      maxAttempts,
+      retryAttempts,
       abortController,
     );
   }

--- a/lib/src/storage_client.dart
+++ b/lib/src/storage_client.dart
@@ -4,7 +4,7 @@ import 'package:storage_client/src/storage_bucket_api.dart';
 import 'package:storage_client/src/storage_file_api.dart';
 
 class SupabaseStorageClient extends StorageBucketApi {
-  final int _defaultMaxAttempts;
+  final int _defaultRetryAttempts;
 
   /// To create a [SupabaseStorageClient], you need to provide an [url] and [headers].
   ///
@@ -14,8 +14,8 @@ class SupabaseStorageClient extends StorageBucketApi {
   ///
   /// [httpClient] is optional and can be used to provide a custom http client
   ///
-  /// [maxAttempts] specifies how many attempts there should be to upload a
-  /// file when failed due to network interruption.
+  /// [retryAttempts] specifies how many retry attempts there should be to
+  ///  upload a file when failed due to network interruption.
   ///
   /// Time between each retries are set as the following:
   ///  1. 400 ms +/- 25%
@@ -32,12 +32,12 @@ class SupabaseStorageClient extends StorageBucketApi {
     String url,
     Map<String, String> headers, {
     Client? httpClient,
-    int maxAttempts = 1,
+    int retryAttempts = 0,
   })  : assert(
-          maxAttempts >= 1,
-          'maxAttempts has to be great than or equal to 1',
+          retryAttempts >= 0,
+          'retryAttempts has to be great than or equal to 0',
         ),
-        _defaultMaxAttempts = maxAttempts,
+        _defaultRetryAttempts = retryAttempts,
         super(
           url,
           {...Constants.defaultHeaders, ...headers},
@@ -48,6 +48,6 @@ class SupabaseStorageClient extends StorageBucketApi {
   ///
   /// [id] The bucket id to operate on.
   StorageFileApi from(String id) {
-    return StorageFileApi(url, headers, id, _defaultMaxAttempts);
+    return StorageFileApi(url, headers, id, _defaultRetryAttempts);
   }
 }

--- a/lib/src/storage_client.dart
+++ b/lib/src/storage_client.dart
@@ -4,11 +4,41 @@ import 'package:storage_client/src/storage_bucket_api.dart';
 import 'package:storage_client/src/storage_file_api.dart';
 
 class SupabaseStorageClient extends StorageBucketApi {
+  final int _defaultMaxAttempts;
+
+  /// To create a [SupabaseStorageClient], you need to provide an [url] and [headers].
+  ///
+  /// ```dart
+  /// SupabaseStorageClient(STORAGE_URL, {'apikey': 'foo'});
+  /// ```
+  ///
+  /// [httpClient] is optional and can be used to provide a custom http client
+  ///
+  /// [maxAttempts] specifies how many attempts there should be to upload a
+  /// file when failed due to network interruption.
+  ///
+  /// Time between each retries are set as the following:
+  ///  1. 400 ms +/- 25%
+  ///  2. 800 ms +/- 25%
+  ///  3. 1600 ms +/- 25%
+  ///  4. 3200 ms +/- 25%
+  ///  5. 6400 ms +/- 25%
+  ///  6. 12800 ms +/- 25%
+  ///  7. 25600 ms +/- 25%
+  ///  8. 30000 ms +/- 25%
+  ///
+  /// Anything beyond the 8th try will have 30 second delay.
   SupabaseStorageClient(
     String url,
     Map<String, String> headers, {
     Client? httpClient,
-  }) : super(
+    int maxAttempts = 1,
+  })  : assert(
+          maxAttempts >= 1,
+          'maxAttempts has to be great than or equal to 1',
+        ),
+        _defaultMaxAttempts = maxAttempts,
+        super(
           url,
           {...Constants.defaultHeaders, ...headers},
           httpClient: httpClient,
@@ -18,6 +48,6 @@ class SupabaseStorageClient extends StorageBucketApi {
   ///
   /// [id] The bucket id to operate on.
   StorageFileApi from(String id) {
-    return StorageFileApi(url, headers, id);
+    return StorageFileApi(url, headers, id, _defaultMaxAttempts);
   }
 }

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -43,7 +43,7 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 40,
+    int maxAttempts = 25,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -86,7 +86,7 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 40,
+    int maxAttempts = 25,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -124,7 +124,7 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 40,
+    int maxAttempts = 25,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -168,7 +168,7 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 40,
+    int maxAttempts = 25,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -37,6 +37,7 @@ class StorageFileApi {
     File file, {
     FileOptions fileOptions = const FileOptions(),
     int? maxAttempts,
+    StorageAbortController? abortController,
   }) async {
     assert(maxAttempts == null || maxAttempts >= 1,
         'maxAttempts has to be greater or equal to 1');
@@ -47,6 +48,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       maxAttempts: maxAttempts ?? _maxAttempts,
+      abortController: abortController,
     );
 
     return (response as Map)['Key'] as String;
@@ -68,6 +70,7 @@ class StorageFileApi {
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
     int? maxAttempts,
+    StorageAbortController? abortController,
   }) async {
     assert(maxAttempts == null || maxAttempts >= 1,
         'maxAttempts has to be greater or equal to 1');
@@ -78,6 +81,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       maxAttempts: maxAttempts ?? _maxAttempts,
+      abortController: abortController,
     );
 
     return (response as Map)['Key'] as String;
@@ -98,6 +102,7 @@ class StorageFileApi {
     File file, {
     FileOptions fileOptions = const FileOptions(),
     int? maxAttempts,
+    StorageAbortController? abortController,
   }) async {
     assert(maxAttempts == null || maxAttempts >= 1,
         'maxAttempts has to be greater or equal to 1');
@@ -108,6 +113,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       maxAttempts: maxAttempts ?? _maxAttempts,
+      abortController: abortController,
     );
 
     return (response as Map<String, dynamic>)['Key'] as String;
@@ -130,6 +136,7 @@ class StorageFileApi {
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
     int? maxAttempts,
+    StorageAbortController? abortController,
   }) async {
     assert(maxAttempts == null || maxAttempts >= 1,
         'maxAttempts has to be greater or equal to 1');
@@ -140,6 +147,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       maxAttempts: maxAttempts ?? _maxAttempts,
+      abortController: abortController,
     );
 
     return (response as Map)['Key'] as String;

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -32,12 +32,14 @@ class StorageFileApi {
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
+  ///
+  /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
   Future<String> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -48,7 +50,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       retryAttempts: retryAttempts ?? _retryAttempts,
-      abortController: abortController,
+      retryController: retryController,
     );
 
     return (response as Map)['Key'] as String;
@@ -65,12 +67,14 @@ class StorageFileApi {
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
+  ///
+  /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
   Future<String> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -81,7 +85,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       retryAttempts: retryAttempts ?? _retryAttempts,
-      abortController: abortController,
+      retryController: retryController,
     );
 
     return (response as Map)['Key'] as String;
@@ -97,12 +101,14 @@ class StorageFileApi {
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
+  ///
+  /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
   Future<String> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -113,7 +119,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       retryAttempts: retryAttempts ?? _retryAttempts,
-      abortController: abortController,
+      retryController: retryController,
     );
 
     return (response as Map<String, dynamic>)['Key'] as String;
@@ -131,12 +137,14 @@ class StorageFileApi {
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
   /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
+  ///
+  /// You can pass a [retryController] and call `cancel()` to cancel the retry attempts.
   Future<String> updateBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
-    StorageAbortController? abortController,
+    StorageRetryController? retryController,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -147,7 +155,7 @@ class StorageFileApi {
       fileOptions,
       options: FetchOptions(headers: headers),
       retryAttempts: retryAttempts ?? _retryAttempts,
-      abortController: abortController,
+      retryController: retryController,
     );
 
     return (response as Map)['Key'] as String;

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -8,13 +8,13 @@ class StorageFileApi {
   final String url;
   final Map<String, String> headers;
   final String? bucketId;
-  final int _maxAttempts;
+  final int _retryAttempts;
 
   const StorageFileApi(
     this.url,
     this.headers,
     this.bucketId,
-    this._maxAttempts,
+    this._retryAttempts,
   );
 
   String _getFinalPath(String path) {
@@ -31,23 +31,23 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
+  /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   Future<String> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int? maxAttempts,
+    int? retryAttempts,
     StorageAbortController? abortController,
   }) async {
-    assert(maxAttempts == null || maxAttempts >= 1,
-        'maxAttempts has to be greater or equal to 1');
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts ?? _maxAttempts,
+      maxAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -64,23 +64,23 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
+  /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   Future<String> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int? maxAttempts,
+    int? retryAttempts,
     StorageAbortController? abortController,
   }) async {
-    assert(maxAttempts == null || maxAttempts >= 1,
-        'maxAttempts has to be greater or equal to 1');
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts ?? _maxAttempts,
+      maxAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -96,23 +96,23 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
+  /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   Future<String> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int? maxAttempts,
+    int? retryAttempts,
     StorageAbortController? abortController,
   }) async {
-    assert(maxAttempts == null || maxAttempts >= 1,
-        'maxAttempts has to be greater or equal to 1');
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts ?? _maxAttempts,
+      maxAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -130,23 +130,23 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
+  /// [retryAttempts] overrides the retryAttempts parameter set across the storage client.
   Future<String> updateBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int? maxAttempts,
+    int? retryAttempts,
     StorageAbortController? abortController,
   }) async {
-    assert(maxAttempts == null || maxAttempts >= 1,
-        'maxAttempts has to be greater or equal to 1');
+    assert(retryAttempts == null || retryAttempts >= 0,
+        'retryAttempts has to be greater or equal to 0');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts ?? _maxAttempts,
+      maxAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -8,8 +8,14 @@ class StorageFileApi {
   final String url;
   final Map<String, String> headers;
   final String? bucketId;
+  final int _maxAttempts;
 
-  const StorageFileApi(this.url, this.headers, this.bucketId);
+  const StorageFileApi(
+    this.url,
+    this.headers,
+    this.bucketId,
+    this._maxAttempts,
+  );
 
   String _getFinalPath(String path) {
     return '$bucketId/$path';
@@ -25,34 +31,22 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] specifies how many attempts there should be to upload the
-  /// file when failed due to network interruption.
-  ///
-  /// Time between each retries are set as the following:
-  ///  1. 400 ms +/- 25%
-  ///  2. 800 ms +/- 25%
-  ///  3. 1600 ms +/- 25%
-  ///  4. 3200 ms +/- 25%
-  ///  5. 6400 ms +/- 25%
-  ///  6. 12800 ms +/- 25%
-  ///  7. 25600 ms +/- 25%
-  ///  8. 30000 ms +/- 25%
-  ///
-  /// Anything beyond the 8th try will have 30 second delay.
+  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
   Future<String> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 25,
+    int? maxAttempts,
   }) async {
-    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
+    assert(maxAttempts == null || maxAttempts >= 1,
+        'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts,
+      maxAttempts: maxAttempts ?? _maxAttempts,
     );
 
     return (response as Map)['Key'] as String;
@@ -68,34 +62,22 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] specifies how many attempts there should be to upload the
-  /// file when failed due to network interruption.
-  ///
-  /// Time between each retries are set as the following:
-  ///  1. 400 ms +/- 25%
-  ///  2. 800 ms +/- 25%
-  ///  3. 1600 ms +/- 25%
-  ///  4. 3200 ms +/- 25%
-  ///  5. 6400 ms +/- 25%
-  ///  6. 12800 ms +/- 25%
-  ///  7. 25600 ms +/- 25%
-  ///  8. 30000 ms +/- 25%
-  ///
-  /// Anything beyond the 8th try will have 30 second delay.
+  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
   Future<String> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 25,
+    int? maxAttempts,
   }) async {
-    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
+    assert(maxAttempts == null || maxAttempts >= 1,
+        'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts,
+      maxAttempts: maxAttempts ?? _maxAttempts,
     );
 
     return (response as Map)['Key'] as String;
@@ -110,34 +92,22 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] specifies how many attempts there should be to upload the
-  /// file when failed due to network interruption.
-  ///
-  /// Time between each retries are set as the following:
-  ///  1. 400 ms +/- 25%
-  ///  2. 800 ms +/- 25%
-  ///  3. 1600 ms +/- 25%
-  ///  4. 3200 ms +/- 25%
-  ///  5. 6400 ms +/- 25%
-  ///  6. 12800 ms +/- 25%
-  ///  7. 25600 ms +/- 25%
-  ///  8. 30000 ms +/- 25%
-  ///
-  /// Anything beyond the 8th try will have 30 second delay.
+  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
   Future<String> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 25,
+    int? maxAttempts,
   }) async {
-    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
+    assert(maxAttempts == null || maxAttempts >= 1,
+        'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts,
+      maxAttempts: maxAttempts ?? _maxAttempts,
     );
 
     return (response as Map<String, dynamic>)['Key'] as String;
@@ -154,34 +124,22 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// [maxAttempts] specifies how many attempts there should be to upload the
-  /// file when failed due to network interruption.
-  ///
-  /// Time between each retries are set as the following:
-  ///  1. 400 ms +/- 25%
-  ///  2. 800 ms +/- 25%
-  ///  3. 1600 ms +/- 25%
-  ///  4. 3200 ms +/- 25%
-  ///  5. 6400 ms +/- 25%
-  ///  6. 12800 ms +/- 25%
-  ///  7. 25600 ms +/- 25%
-  ///  8. 30000 ms +/- 25%
-  ///
-  /// Anything beyond the 8th try will have 30 second delay.
+  /// [maxAttempts] overrides the maxAttempts parameter set across the storage client.
   Future<String> updateBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 25,
+    int? maxAttempts,
   }) async {
-    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
+    assert(maxAttempts == null || maxAttempts >= 1,
+        'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: maxAttempts,
+      maxAttempts: maxAttempts ?? _maxAttempts,
     );
 
     return (response as Map)['Key'] as String;

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -43,7 +43,7 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 8,
+    int maxAttempts = 40,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -86,7 +86,7 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 8,
+    int maxAttempts = 40,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -124,7 +124,7 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 8,
+    int maxAttempts = 40,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
@@ -168,7 +168,7 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int maxAttempts = 8,
+    int maxAttempts = 40,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -91,8 +91,12 @@ class StorageFileApi {
     assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postBinaryFile(
-        '$url/object/$finalPath', data, fileOptions,
-        options: FetchOptions(headers: headers), maxAttempts: maxAttempts);
+      '$url/object/$finalPath',
+      data,
+      fileOptions,
+      options: FetchOptions(headers: headers),
+      maxAttempts: maxAttempts,
+    );
 
     return (response as Map)['Key'] as String;
   }

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -47,7 +47,7 @@ class StorageFileApi {
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: retryAttempts ?? _retryAttempts,
+      retryAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -80,7 +80,7 @@ class StorageFileApi {
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: retryAttempts ?? _retryAttempts,
+      retryAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -112,7 +112,7 @@ class StorageFileApi {
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: retryAttempts ?? _retryAttempts,
+      retryAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 
@@ -146,7 +146,7 @@ class StorageFileApi {
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
-      maxAttempts: retryAttempts ?? _retryAttempts,
+      retryAttempts: retryAttempts ?? _retryAttempts,
       abortController: abortController,
     );
 

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -24,10 +24,26 @@ class StorageFileApi {
   /// [file] is the File object to be stored in the bucket.
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
+  ///
+  /// If [retryCount] is specified, failed upload operation
+  /// due to `SocketException` or `TimeoutException` will be retried.
+  ///
+  /// Time between each retries are set as the following:
+  ///  1. 400 ms +/- 25%
+  ///  2. 800 ms +/- 25%
+  ///  3. 1600 ms +/- 25%
+  ///  4. 3200 ms +/- 25%
+  ///  5. 6400 ms +/- 25%
+  ///  6. 12800 ms +/- 25%
+  ///  7. 25600 ms +/- 25%
+  ///  8. 30000 ms +/- 25%
+  ///
+  /// Anything beyond the 8th try will have 30 second delay.
   Future<String> upload(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
+    int retryCount = 0,
   }) async {
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postFile(
@@ -35,6 +51,7 @@ class StorageFileApi {
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
+      retryCount: retryCount,
     );
 
     return (response as Map)['Key'] as String;
@@ -49,10 +66,26 @@ class StorageFileApi {
   /// [data] is the binary file data to be stored in the bucket.
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
+  ///
+  /// If [retryCount] is specified, failed upload operation
+  /// due to `SocketException` or `TimeoutException` will be retried.
+  ///
+  /// Time between each retries are set as the following:
+  ///  1. 400 ms +/- 25%
+  ///  2. 800 ms +/- 25%
+  ///  3. 1600 ms +/- 25%
+  ///  4. 3200 ms +/- 25%
+  ///  5. 6400 ms +/- 25%
+  ///  6. 12800 ms +/- 25%
+  ///  7. 25600 ms +/- 25%
+  ///  8. 30000 ms +/- 25%
+  ///
+  /// Anything beyond the 8th try will have 30 second delay.
   Future<String> uploadBinary(
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
+    int? retryCount,
   }) async {
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postBinaryFile(
@@ -73,10 +106,26 @@ class StorageFileApi {
   /// [file] is the file object to be stored in the bucket.
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
+  ///
+  /// If [retryCount] is specified, failed upload operation
+  /// due to `SocketException` or `TimeoutException` will be retried.
+  ///
+  /// Time between each retries are set as the following:
+  ///  1. 400 ms +/- 25%
+  ///  2. 800 ms +/- 25%
+  ///  3. 1600 ms +/- 25%
+  ///  4. 3200 ms +/- 25%
+  ///  5. 6400 ms +/- 25%
+  ///  6. 12800 ms +/- 25%
+  ///  7. 25600 ms +/- 25%
+  ///  8. 30000 ms +/- 25%
+  ///
+  /// Anything beyond the 8th try will have 30 second delay.
   Future<String> update(
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
+    int retryCount = 0,
   }) async {
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putFile(
@@ -84,6 +133,7 @@ class StorageFileApi {
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
+      retryCount: retryCount,
     );
 
     return (response as Map<String, dynamic>)['Key'] as String;
@@ -99,6 +149,21 @@ class StorageFileApi {
   /// [data] is the binary file data to be stored in the bucket.
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
+  ///
+  /// If [retryCount] is specified, failed upload operation
+  /// due to `SocketException` or `TimeoutException` will be retried.
+  ///
+  /// Time between each retries are set as the following:
+  ///  1. 400 ms +/- 25%
+  ///  2. 800 ms +/- 25%
+  ///  3. 1600 ms +/- 25%
+  ///  4. 3200 ms +/- 25%
+  ///  5. 6400 ms +/- 25%
+  ///  6. 12800 ms +/- 25%
+  ///  7. 25600 ms +/- 25%
+  ///  8. 30000 ms +/- 25%
+  ///
+  /// Anything beyond the 8th try will have 30 second delay.
   Future<String> updateBinary(
     String path,
     Uint8List data, {

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -25,8 +25,8 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// If [retryCount] is specified, failed upload operation
-  /// due to `SocketException` or `TimeoutException` will be retried.
+  /// [maxAttempts] specifies how many attempts there should be to upload the
+  /// file when failed due to network interruption.
   ///
   /// Time between each retries are set as the following:
   ///  1. 400 ms +/- 25%
@@ -43,15 +43,16 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int retryCount = 0,
+    int maxAttempts = 8,
   }) async {
+    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      retryCount: retryCount,
+      maxAttempts: maxAttempts,
     );
 
     return (response as Map)['Key'] as String;
@@ -67,8 +68,8 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// If [retryCount] is specified, failed upload operation
-  /// due to `SocketException` or `TimeoutException` will be retried.
+  /// [maxAttempts] specifies how many attempts there should be to upload the
+  /// file when failed due to network interruption.
   ///
   /// Time between each retries are set as the following:
   ///  1. 400 ms +/- 25%
@@ -85,15 +86,13 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
-    int? retryCount,
+    int maxAttempts = 8,
   }) async {
+    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.postBinaryFile(
-      '$url/object/$finalPath',
-      data,
-      fileOptions,
-      options: FetchOptions(headers: headers),
-    );
+        '$url/object/$finalPath', data, fileOptions,
+        options: FetchOptions(headers: headers), maxAttempts: maxAttempts);
 
     return (response as Map)['Key'] as String;
   }
@@ -107,8 +106,8 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// If [retryCount] is specified, failed upload operation
-  /// due to `SocketException` or `TimeoutException` will be retried.
+  /// [maxAttempts] specifies how many attempts there should be to upload the
+  /// file when failed due to network interruption.
   ///
   /// Time between each retries are set as the following:
   ///  1. 400 ms +/- 25%
@@ -125,15 +124,16 @@ class StorageFileApi {
     String path,
     File file, {
     FileOptions fileOptions = const FileOptions(),
-    int retryCount = 0,
+    int maxAttempts = 8,
   }) async {
+    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putFile(
       '$url/object/$finalPath',
       file,
       fileOptions,
       options: FetchOptions(headers: headers),
-      retryCount: retryCount,
+      maxAttempts: maxAttempts,
     );
 
     return (response as Map<String, dynamic>)['Key'] as String;
@@ -150,8 +150,8 @@ class StorageFileApi {
   ///
   /// [fileOptions] HTTP headers. For example `cacheControl`
   ///
-  /// If [retryCount] is specified, failed upload operation
-  /// due to `SocketException` or `TimeoutException` will be retried.
+  /// [maxAttempts] specifies how many attempts there should be to upload the
+  /// file when failed due to network interruption.
   ///
   /// Time between each retries are set as the following:
   ///  1. 400 ms +/- 25%
@@ -168,13 +168,16 @@ class StorageFileApi {
     String path,
     Uint8List data, {
     FileOptions fileOptions = const FileOptions(),
+    int maxAttempts = 8,
   }) async {
+    assert(maxAttempts >= 1, 'maxAttempts has to be greater or equal to 1');
     final finalPath = _getFinalPath(path);
     final response = await storageFetch.putBinaryFile(
       '$url/object/$finalPath',
       data,
       fileOptions,
       options: FetchOptions(headers: headers),
+      maxAttempts: maxAttempts,
     );
 
     return (response as Map)['Key'] as String;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -191,3 +191,16 @@ class StorageException implements Exception {
     return 'StorageException(message: $message, statusCode: $statusCode, error: $error)';
   }
 }
+
+class StorageAbortController {
+  bool get aborted => _aborted;
+  bool _aborted = false;
+
+  /// Creates a controller to abort storage file upload retry operations.
+  StorageAbortController();
+
+  /// Aborts the next retry operation
+  void abort() {
+    _aborted = true;
+  }
+}

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -192,16 +192,16 @@ class StorageException implements Exception {
   }
 }
 
-class StorageAbortController {
+class StorageRetryController {
   /// Whether the retry operation is aborted
-  bool get aborted => _aborted;
-  bool _aborted = false;
+  bool get cancelled => _cancelled;
+  bool _cancelled = false;
 
   /// Creates a controller to abort storage file upload retry operations.
-  StorageAbortController();
+  StorageRetryController();
 
   /// Aborts the next retry operation
-  void abort() {
-    _aborted = true;
+  void cancel() {
+    _cancelled = true;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,14 @@ homepage: "https://supabase.io"
 repository: "https://github.com/supabase/storage-dart"
 
 environment:
-  sdk: ">=2.14.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   http: ^0.13.4
   http_parser: ^4.0.1
   mime: ^1.0.2
   universal_io: ^2.0.4
+  retry: ^3.1.0
 
 dev_dependencies:
   mocktail: ^0.3.0

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -166,7 +166,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          maxAttempts: 8,
+          maxAttempts: 1,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),
@@ -187,7 +187,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          maxAttempts: 8,
+          maxAttempts: 1,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),
@@ -301,9 +301,11 @@ void main() {
   group('Retry', () {
     setUp(() {
       // init SupabaseClient with test url & test key
-      client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
-        'Authorization': 'Bearer $supabaseKey',
-      });
+      client = SupabaseStorageClient(
+        '$supabaseUrl/storage/v1',
+        {'Authorization': 'Bearer $supabaseKey'},
+        maxAttempts: 3,
+      );
 
       // `RetryHttpClient` will throw `SocketException` for the first two tries
       storageFetch = Fetch(RetryHttpClient());

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -167,7 +167,7 @@ void main() {
           mockFileOptions,
           options: mockFetchOptions,
           retryAttempts: 0,
-          abortController: null,
+          retryController: null,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),
@@ -189,7 +189,7 @@ void main() {
           mockFileOptions,
           options: mockFetchOptions,
           retryAttempts: 0,
-          abortController: null,
+          retryController: null,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),
@@ -335,16 +335,16 @@ void main() {
       final file = File('a.txt');
       file.writeAsStringSync('File content');
 
-      final abortController = StorageAbortController();
+      final retryController = StorageRetryController();
 
       final future = client.from('public').upload(
             'a.txt',
             file,
-            abortController: abortController,
+            retryController: retryController,
           );
 
       await Future.delayed(Duration(milliseconds: 500));
-      abortController.abort();
+      retryController.cancel();
 
       expect(future, throwsException);
     });

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -304,23 +304,6 @@ void main() {
       client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
         'Authorization': 'Bearer $supabaseKey',
       });
-      storageFetch = Fetch(CustomHttpClient());
-    });
-    test('should list buckets', () async {
-      try {
-        await client.listBuckets();
-      } catch (e) {
-        expect((e as dynamic).statusCode, "420");
-      }
-    });
-  });
-
-  group('Retry', () {
-    setUp(() {
-      // init SupabaseClient with test url & test key
-      client = SupabaseStorageClient('$supabaseUrl/storage/v1', {
-        'Authorization': 'Bearer $supabaseKey',
-      });
 
       // `RetryHttpClient` will throw `SocketException` for the first two tries
       storageFetch = Fetch(RetryHttpClient());

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -166,7 +166,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          maxAttempts: 1,
+          retryAttempts: 1,
           abortController: null,
         ),
       ).thenAnswer(
@@ -188,7 +188,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          maxAttempts: 1,
+          retryAttempts: 1,
           abortController: null,
         ),
       ).thenAnswer(
@@ -306,7 +306,7 @@ void main() {
       client = SupabaseStorageClient(
         '$supabaseUrl/storage/v1',
         {'Authorization': 'Bearer $supabaseKey'},
-        maxAttempts: 5,
+        retryAttempts: 5,
       );
 
       // `RetryHttpClient` will throw `SocketException` for the first two tries

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -331,7 +331,7 @@ void main() {
       expect(response.endsWith('/a.txt'), isTrue);
     });
 
-    test('aborting upload shoudl throw', () async {
+    test('aborting upload should throw', () async {
       final file = File('a.txt');
       file.writeAsStringSync('File content');
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -318,7 +318,7 @@ void main() {
       file.writeAsStringSync('File content');
 
       final uploadTask =
-          client.from('public').upload('a.txt', file, maxAttempts: 1);
+          client.from('public').upload('a.txt', file, retryAttempts: 1);
       expect(uploadTask, throwsException);
     });
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -166,6 +166,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
+          retryCount: 0,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),
@@ -186,6 +187,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
+          retryCount: 0,
         ),
       ).thenAnswer(
         (_) => Future.value({'Key': 'public/a.txt'}),

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -166,7 +166,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          retryAttempts: 1,
+          retryAttempts: 0,
           abortController: null,
         ),
       ).thenAnswer(
@@ -188,7 +188,7 @@ void main() {
           file,
           mockFileOptions,
           options: mockFetchOptions,
-          retryAttempts: 1,
+          retryAttempts: 0,
           abortController: null,
         ),
       ).thenAnswer(

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -20,7 +20,7 @@ class RetryHttpClient extends BaseClient {
   int failureCount = 0;
   @override
   Future<StreamedResponse> send(BaseRequest request) async {
-    if (failureCount < 2) {
+    if (failureCount < 3) {
       failureCount++;
       throw SocketException('Offline');
     }

--- a/test/custom_http_client.dart
+++ b/test/custom_http_client.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:http/http.dart';
+import 'package:universal_io/io.dart';
 
 class CustomHttpClient extends BaseClient {
   @override
@@ -7,6 +10,24 @@ class CustomHttpClient extends BaseClient {
     return StreamedResponse(
       request.finalize(),
       420,
+      request: request,
+    );
+  }
+}
+
+/// Client that fails for few times when attempting to upload file
+class RetryHttpClient extends BaseClient {
+  int failureCount = 0;
+  @override
+  Future<StreamedResponse> send(BaseRequest request) async {
+    if (failureCount < 2) {
+      failureCount++;
+      throw SocketException('Offline');
+    }
+    //Return custom status code to check for usage of this client.
+    return StreamedResponse(
+      Stream.value(utf8.encode(jsonEncode({'Key': 'public/a.txt'}))),
+      201,
       request: request,
     );
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Uploading large files on a spotty connection could be tough. 

- Support [Resumable uploads](https://cloud.google.com/storage/docs/resumable-uploads)
- Retry failed requests

Resumable uploads is not yet supported on Supabase, but we can easily implement retries. This PR adds a retry logic to file uploads in a exponentially backing off manner like the following:

1. 400 ms +/- 25%
2. 800 ms +/- 25%
3. 1,600 ms +/- 25%
4. 3,200 ms +/- 25%
5. 6,400 ms +/- 25%
6. 12,800 ms +/- 25%
7. 25,600 ms +/- 25%
8. and beyond 30,000 ms +/- 25%

By default, the max attempts is set to 25, which should be roughly 10 minutes. 10 minutes was the default time set for Firebase storage. Users can change the retry count like the following. Not sure if this API would provide the best developer experience, so would love to hear comments/ suggestions about anything regarding this PR!
```dart
final uploadTask =
    client.from('public').upload('a.txt', file, maxAttempts: 8);
```

## What is the current behavior?

If a file upload fails, it does no retry, which makes is hard to upload large files over a spotty network connection.

## What is the new behavior?

File upload is automatically retried on SocketException or TimeoutException. 

## Additional context

This feature is not supported on JS client, but there was an feedback from customers handling large files. After some internal discussions, we thought it would make make sense to add this feature to the Flutter SDK. 
