### PR TITLE
fix: parse content type

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -86,7 +86,7 @@ class FileOptions {
   const FileOptions({
     this.cacheControl = '3600',
     this.upsert = false,
-    this.contentType = 'text/plain;charset=UTF-8',
+    this.contentType,
   });
 }
 


### PR DESCRIPTION
We check if the content type is already specified [here](https://github.com/supabase/storage-dart/blob/main/lib/src/fetch.dart#L84), which was previously always the case, because it was set in the constructor. Now the correct content type detection should run.

close supabase/supabase-flutter#213
