### PR TITLE
url of api

### DIFF
--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -258,7 +258,7 @@ class StorageFileApi {
     final List<SignedUrl> urls = (response as List).map((e) {
       return SignedUrl(
         path: e['path'],
-        signedUrl: '$url/${e['signedURL']}',
+        signedUrl: '$url${e['signedURL']}',
       );
     }).toList();
     return urls;


### PR DESCRIPTION
the URL of the API was not returned within the signedURL

## What kind of change does this PR introduce?

Fixing supabase/supabase-flutter#411

## What is the current behavior?

unlike createSignedUrl, createSignedUrls does not return a URL. It is missing the API URL

## What is the new behavior?

The URL string has been added
