### PR TITLE
feat: custom file size limit and mime types at bucket level

### DIFF
--- a/infra/storage/Dockerfile
+++ b/infra/storage/Dockerfile
@@ -1,3 +1,3 @@
-FROM supabase/storage-api:v0.25.1
+FROM supabase/storage-api:v0.29.1
 
 RUN apk add curl --no-cache

--- a/lib/src/storage_bucket_api.dart
+++ b/lib/src/storage_bucket_api.dart
@@ -55,7 +55,15 @@ class StorageBucketApi {
     final FetchOptions options = FetchOptions(headers: headers);
     final response = await storageFetch.post(
       '$url/bucket',
-      {'id': id, 'name': id, 'public': bucketOptions.public},
+      {
+        'id': id,
+        'name': id,
+        'public': bucketOptions.public,
+        if (bucketOptions.fileSizeLimit != null)
+          'file_size_limit': bucketOptions.fileSizeLimit,
+        if (bucketOptions.allowedMimeTypes != null)
+          'allowed_mime_types': bucketOptions.allowedMimeTypes,
+      },
       options: options,
     );
     final bucketId = (response as Map<String, dynamic>)['name'] as String;
@@ -74,7 +82,15 @@ class StorageBucketApi {
     final FetchOptions options = FetchOptions(headers: headers);
     final response = await storageFetch.put(
       '$url/bucket/$id',
-      {'id': id, 'name': id, 'public': bucketOptions.public},
+      {
+        'id': id,
+        'name': id,
+        'public': bucketOptions.public,
+        if (bucketOptions.fileSizeLimit != null)
+          'file_size_limit': bucketOptions.fileSizeLimit,
+        if (bucketOptions.allowedMimeTypes != null)
+          'allowed_mime_types': bucketOptions.allowedMimeTypes,
+      },
       options: options,
     );
     final message = (response as Map<String, dynamic>)['message'] as String;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -12,6 +12,8 @@ class Bucket {
   final String createdAt;
   final String updatedAt;
   final bool public;
+  final int? fileSizeLimit;
+  final List<String>? allowedMimeTypes;
 
   const Bucket({
     required this.id,
@@ -20,6 +22,8 @@ class Bucket {
     required this.createdAt,
     required this.updatedAt,
     required this.public,
+    this.fileSizeLimit,
+    this.allowedMimeTypes,
   });
 
   Bucket.fromJson(Map<String, dynamic> json)
@@ -28,7 +32,11 @@ class Bucket {
         owner = json['owner'] as String,
         createdAt = json['created_at'] as String,
         updatedAt = json['updated_at'] as String,
-        public = json['public'] as bool;
+        public = json['public'] as bool,
+        fileSizeLimit = json['file_size_limit'] as int?,
+        allowedMimeTypes = json['allowed_mime_types'] == null
+            ? null
+            : List<String>.from(json['allowed_mime_types'] as List);
 }
 
 class FileObject {
@@ -67,10 +75,23 @@ class FileObject {
             json['buckets'] != null ? Bucket.fromJson(json['buckets']) : null;
 }
 
+/// [public] The visibility of the bucket. Public buckets don't require an
+/// authorization token to download objects, but still require a valid token for
+/// all other operations. By default, buckets are private.
+///
+/// [fileSizeLimit] specifies the file size limit that this bucket can accept during upload
+///
+/// [allowedMimeTypes] specifies the allowed mime types that this bucket can accept during upload
 class BucketOptions {
   final bool public;
+  final int? fileSizeLimit;
+  final List<String>? allowedMimeTypes;
 
-  const BucketOptions({required this.public});
+  const BucketOptions({
+    required this.public,
+    this.fileSizeLimit,
+    this.allowedMimeTypes,
+  });
 }
 
 class FileOptions {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -79,12 +79,13 @@ class FileObject {
 /// authorization token to download objects, but still require a valid token for
 /// all other operations. By default, buckets are private.
 ///
-/// [fileSizeLimit] specifies the file size limit that this bucket can accept during upload
+/// [fileSizeLimit] specifies the file size limit that this bucket can accept during upload.
+/// It should be in a format such as `20GB`, `20MB`, `30KB`, or `3B`
 ///
 /// [allowedMimeTypes] specifies the allowed mime types that this bucket can accept during upload
 class BucketOptions {
   final bool public;
-  final int? fileSizeLimit;
+  final String? fileSizeLimit;
   final List<String>? allowedMimeTypes;
 
   const BucketOptions({

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -219,7 +219,7 @@ void main() {
           bucketName,
           const BucketOptions(
             public: true,
-            fileSizeLimit: '1mb',
+            fileSizeLimit: '1kb',
           ));
 
       final uploadFuture = storage.from(bucketName).upload(uploadPath, file);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -91,7 +91,7 @@ void main() {
       newBucketName,
       const BucketOptions(
         public: true,
-        fileSizeLimit: 20000000, // 20 mb
+        fileSizeLimit: '20mb', // 20 mb
         allowedMimeTypes: ['image/jpeg'],
       ),
     );
@@ -110,7 +110,7 @@ void main() {
       newBucketName,
       const BucketOptions(
         public: true,
-        fileSizeLimit: 20000000, // 20 mb
+        fileSizeLimit: '20mb', // 20 mb
         allowedMimeTypes: ['image/jpeg'],
       ),
     );
@@ -206,7 +206,7 @@ void main() {
           bucketName,
           const BucketOptions(
             public: true,
-            fileSizeLimit: 1000000, // 1mb
+            fileSizeLimit: '1mb', // 1mb
           ));
 
       final res = await storage.from(bucketName).upload(uploadPath, file);
@@ -219,7 +219,7 @@ void main() {
           bucketName,
           const BucketOptions(
             public: true,
-            fileSizeLimit: 1000000, // 1mb
+            fileSizeLimit: '1mb',
           ));
 
       final uploadFuture = storage.from(bucketName).upload(uploadPath, file);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

Dart implementation of this https://github.com/supabase/storage-js/pull/151

## What is the new behavior?

It is now possible to specify, `file_size_limit` and `allowed_mime_types` when creating a bucket.
These limits will be imposed during the upload of an asset, allowing you to validate server side the values

Example:

```dart

// Create Bucket with file size limit 20mb
await storage.createBucket(
  newBucketName,
  const BucketOptions(
    public: true,
    fileSizeLimit: 20000000, // 20 mb
    allowedMimeTypes: ['image/jpeg'],
  ),
);

// load the file
final bigFile = ... // 1GB

// Upload
await storage.from(bucketName).upload(uploadPath, bigFile); // throws an error
```