### PR TITLE
feat: add a quality option for image transformation

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -257,11 +257,15 @@ class TransformOptions {
   /// [ResizeMode.cover] will be used if no value is specified.
   final ResizeMode? resize;
 
+  /// Set the quality of the returned image, this is percentage based, default 80
+  final int? quality;
+
   /// {@macro transform_options}
   const TransformOptions({
     this.width,
     this.height,
     this.resize,
+    this.quality,
   });
 }
 
@@ -271,6 +275,7 @@ extension ToQueryParams on TransformOptions {
       if (width != null) 'width': '$width',
       if (height != null) 'height': '$height',
       if (resize != null) 'resize': resize!.snakeCase,
+      if (quality != null) 'quality': '$quality',
     };
   }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -156,10 +156,10 @@ void main() {
 
     test('gets public url with transformation options', () async {
       final url = storage.from(newBucketName).getPublicUrl(uploadPath,
-          transform: TransformOptions(width: 200, height: 300));
+          transform: TransformOptions(width: 200, height: 300, quality: 60));
 
       expect(url,
-          '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300');
+          '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300&quality=60');
     });
 
     test('will download a public transformed file', () async {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

Dart implementation of https://github.com/supabase/storage-js/pull/145

## What is the new behavior?

Implement `quality` option for image transformation
