### PR TITLE
 feat: format option for webp support

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -84,5 +84,6 @@ services:
     environment:
       - IMGPROXY_LOCAL_FILESYSTEM_ROOT=/
       - IMGPROXY_USE_ETAG=true
+      - IMGPROXY_ENABLE_WEBP_DETECTION=true
 volumes:
   assets-volume:

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -281,8 +281,6 @@ class StorageFileApi {
     var fetchUrl = Uri.parse('$url/$renderPath/$finalPath');
     fetchUrl = fetchUrl.replace(queryParameters: queryParams);
 
-    print('headers in download: ${options.headers}');
-
     final response =
         await storageFetch.get(fetchUrl.toString(), options: options);
     return response as Uint8List;

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -281,6 +281,8 @@ class StorageFileApi {
     var fetchUrl = Uri.parse('$url/$renderPath/$finalPath');
     fetchUrl = fetchUrl.replace(queryParameters: queryParams);
 
+    print('headers in download: ${options.headers}');
+
     final response =
         await storageFetch.get(fetchUrl.toString(), options: options);
     return response as Uint8List;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -242,6 +242,10 @@ enum ResizeMode {
   fill,
 }
 
+enum RequestImageFormat {
+  origin,
+}
+
 /// {@template transform_options}
 /// Specifies the dimensions and the resize mode of the requesting image.
 /// {@endtemplate}
@@ -260,12 +264,19 @@ class TransformOptions {
   /// Set the quality of the returned image, this is percentage based, default 80
   final int? quality;
 
+  ///  Specify the format of the image requested.
+  ///
+  ///  When using 'origin' we force the format to be the same as the original image,
+  ///  bypassing automatic browser optimisation such as webp conversion
+  final RequestImageFormat? format;
+
   /// {@macro transform_options}
   const TransformOptions({
     this.width,
     this.height,
     this.resize,
     this.quality,
+    this.format,
   });
 }
 
@@ -276,6 +287,7 @@ extension ToQueryParams on TransformOptions {
       if (height != null) 'height': '$height',
       if (resize != null) 'resize': resize!.snakeCase,
       if (quality != null) 'quality': '$quality',
+      if (format != null) 'format': format!.snakeCase,
     };
   }
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -257,11 +257,15 @@ class TransformOptions {
   /// [ResizeMode.cover] will be used if no value is specified.
   final ResizeMode? resize;
 
+  /// Set the quality of the returned image, this is percentage based, default 80
+  final int? quality;
+
   /// {@macro transform_options}
   const TransformOptions({
     this.width,
     this.height,
     this.resize,
+    this.quality,
   });
 }
 
@@ -271,6 +275,7 @@ extension ToQueryParams on TransformOptions {
       if (width != null) 'width': '$width',
       if (height != null) 'height': '$height',
       if (resize != null) 'resize': resize!.snakeCase,
+      if (quality != null) 'quality': '$quality',
     };
   }
 }

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -201,12 +201,8 @@ void main() {
     test('will return the image as webp when the browser support it', () async {
       final storage = SupabaseStorageClient(storageUrl,
           {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
-      final privateBucketName = 'my-private-bucket';
-      await findOrCreateBucket(privateBucketName);
 
-      await storage.from(privateBucketName).upload(uploadPath, file);
-
-      final bytesArray = await storage.from(privateBucketName).download(
+      final bytesArray = await storage.from(newBucketName).download(
             uploadPath,
             transform: TransformOptions(
               width: 200,
@@ -227,12 +223,8 @@ void main() {
         () async {
       final storage = SupabaseStorageClient(storageUrl,
           {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
-      final privateBucketName = 'my-private-bucket';
-      await findOrCreateBucket(privateBucketName);
 
-      await storage.from(privateBucketName).upload(uploadPath, file);
-
-      final bytesArray = await storage.from(privateBucketName).download(
+      final bytesArray = await storage.from(newBucketName).download(
             uploadPath,
             transform: TransformOptions(
               width: 200,

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -210,7 +210,7 @@ void main() {
             ),
           );
       final downloadedFile =
-          await File('${Directory.current.path}/private-image.jpg').create();
+          await File('${Directory.current.path}/webpimage').create();
       await downloadedFile.writeAsBytes(bytesArray);
       final size = await downloadedFile.length();
       final type = lookupMimeType(downloadedFile.path);
@@ -233,7 +233,7 @@ void main() {
             ),
           );
       final downloadedFile =
-          await File('${Directory.current.path}/private-image.jpg').create();
+          await File('${Directory.current.path}/jpegimage').create();
       await downloadedFile.writeAsBytes(bytesArray);
       final size = await downloadedFile.length();
       final type = lookupMimeType(downloadedFile.path);

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -197,6 +197,58 @@ void main() {
       expect(size, isPositive);
       expect(type, 'image/jpeg');
     });
+
+    test('will return the image as webp when the browser support it', () async {
+      final storage = SupabaseStorageClient(storageUrl,
+          {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
+      final privateBucketName = 'my-private-bucket';
+      await findOrCreateBucket(privateBucketName);
+
+      await storage.from(privateBucketName).upload(uploadPath, file);
+
+      final bytesArray = await storage.from(privateBucketName).download(
+            uploadPath,
+            transform: TransformOptions(
+              width: 200,
+              height: 200,
+            ),
+          );
+      final downloadedFile =
+          await File('${Directory.current.path}/private-image.jpg').create();
+      await downloadedFile.writeAsBytes(bytesArray);
+      final size = await downloadedFile.length();
+      final type = lookupMimeType(downloadedFile.path);
+
+      expect(size, isPositive);
+      expect(type, 'image/webp');
+    });
+
+    test('will return the original image format when format is origin',
+        () async {
+      final storage = SupabaseStorageClient(storageUrl,
+          {'Authorization': 'Bearer $storageKey', 'Accept': 'image/webp'});
+      final privateBucketName = 'my-private-bucket';
+      await findOrCreateBucket(privateBucketName);
+
+      await storage.from(privateBucketName).upload(uploadPath, file);
+
+      final bytesArray = await storage.from(privateBucketName).download(
+            uploadPath,
+            transform: TransformOptions(
+              width: 200,
+              height: 200,
+              format: RequestImageFormat.origin,
+            ),
+          );
+      final downloadedFile =
+          await File('${Directory.current.path}/private-image.jpg').create();
+      await downloadedFile.writeAsBytes(bytesArray);
+      final size = await downloadedFile.length();
+      final type = lookupMimeType(downloadedFile.path);
+
+      expect(size, isPositive);
+      expect(type, 'image/jpeg');
+    });
   });
 
   group('bucket limits', () {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -192,7 +192,10 @@ void main() {
           await File('${Directory.current.path}/private-image.jpg').create();
       await downloadedFile.writeAsBytes(bytesArray);
       final size = await downloadedFile.length();
-      final type = lookupMimeType(downloadedFile.path);
+      final type = lookupMimeType(
+        downloadedFile.path,
+        headerBytes: downloadedFile.readAsBytesSync(),
+      );
 
       expect(size, isPositive);
       expect(type, 'image/jpeg');
@@ -213,7 +216,10 @@ void main() {
           await File('${Directory.current.path}/webpimage').create();
       await downloadedFile.writeAsBytes(bytesArray);
       final size = await downloadedFile.length();
-      final type = lookupMimeType(downloadedFile.path);
+      final type = lookupMimeType(
+        downloadedFile.path,
+        headerBytes: downloadedFile.readAsBytesSync(),
+      );
 
       expect(size, isPositive);
       expect(type, 'image/webp');
@@ -236,7 +242,10 @@ void main() {
           await File('${Directory.current.path}/jpegimage').create();
       await downloadedFile.writeAsBytes(bytesArray);
       final size = await downloadedFile.length();
-      final type = lookupMimeType(downloadedFile.path);
+      final type = lookupMimeType(
+        downloadedFile.path,
+        headerBytes: downloadedFile.readAsBytesSync(),
+      );
 
       expect(size, isPositive);
       expect(type, 'image/jpeg');

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -156,10 +156,10 @@ void main() {
 
     test('gets public url with transformation options', () async {
       final url = storage.from(newBucketName).getPublicUrl(uploadPath,
-          transform: TransformOptions(width: 200, height: 300));
+          transform: TransformOptions(width: 200, height: 300, quality: 60));
 
       expect(url,
-          '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300');
+          '$storageUrl/render/image/public/$newBucketName/$uploadPath?width=200&height=300&quality=60');
     });
 
     test('will download a public transformed file', () async {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Dart implementation of https://github.com/supabase/storage-js/pull/142

This PR is branched out from https://github.com/supabase/storage-dart/pull/59#issuecomment-1505509406

## What is the new behavior?

Introduced a `format` option to request the image in a different format.
Currently, the only value allowed is `origin` which will force the image to be returned with its original format.
If not provided we will automatically optimise the image using webp

## Additional context

```dart
      final bytesArray = await storage.from(privateBucketName).download(
            uploadPath,
            transform: TransformOptions(
              width: 200,
              height: 200,
              format: RequestImageFormat.origin,
            ),
          );
```
