### PR TITLE
Add upload and download progress callbacks for file transfer

### DIFF
--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -40,6 +40,7 @@ class StorageFileApi {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
     StorageRetryController? retryController,
+    ProgressCallback? onSendProgress,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -48,7 +49,10 @@ class StorageFileApi {
       '$url/object/$finalPath',
       file,
       fileOptions,
-      options: FetchOptions(headers: headers),
+      options: FetchOptions(
+        headers: headers,
+        onRequestProgress: onSendProgress,
+      ),
       retryAttempts: retryAttempts ?? _retryAttempts,
       retryController: retryController,
     );
@@ -75,6 +79,7 @@ class StorageFileApi {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
     StorageRetryController? retryController,
+    ProgressCallback? onSendProgress,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -83,7 +88,10 @@ class StorageFileApi {
       '$url/object/$finalPath',
       data,
       fileOptions,
-      options: FetchOptions(headers: headers),
+      options: FetchOptions(
+        headers: headers,
+        onRequestProgress: onSendProgress,
+      ),
       retryAttempts: retryAttempts ?? _retryAttempts,
       retryController: retryController,
     );
@@ -109,6 +117,7 @@ class StorageFileApi {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
     StorageRetryController? retryController,
+    ProgressCallback? onSendProgress,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -117,7 +126,10 @@ class StorageFileApi {
       '$url/object/$finalPath',
       file,
       fileOptions,
-      options: FetchOptions(headers: headers),
+      options: FetchOptions(
+        headers: headers,
+        onRequestProgress: onSendProgress,
+      ),
       retryAttempts: retryAttempts ?? _retryAttempts,
       retryController: retryController,
     );
@@ -145,6 +157,7 @@ class StorageFileApi {
     FileOptions fileOptions = const FileOptions(),
     int? retryAttempts,
     StorageRetryController? retryController,
+    ProgressCallback? onSendProgress,
   }) async {
     assert(retryAttempts == null || retryAttempts >= 0,
         'retryAttempts has to be greater or equal to 0');
@@ -153,7 +166,10 @@ class StorageFileApi {
       '$url/object/$finalPath',
       data,
       fileOptions,
-      options: FetchOptions(headers: headers),
+      options: FetchOptions(
+        headers: headers,
+        onRequestProgress: onSendProgress,
+      ),
       retryAttempts: retryAttempts ?? _retryAttempts,
       retryController: retryController,
     );

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -270,6 +270,8 @@ class StorageFileApi {
   /// name. For example `download('folder/image.png')`.
   ///
   /// [transform] download a transformed variant of the image with the provided options
+  /// [onReceiveProgress] if not null, the download progress will be transmitted
+  /// via this callback.
   Future<Uint8List> download(
     String path, {
     TransformOptions? transform,

--- a/lib/src/storage_file_api.dart
+++ b/lib/src/storage_file_api.dart
@@ -270,13 +270,21 @@ class StorageFileApi {
   /// name. For example `download('folder/image.png')`.
   ///
   /// [transform] download a transformed variant of the image with the provided options
-  Future<Uint8List> download(String path, {TransformOptions? transform}) async {
+  Future<Uint8List> download(
+    String path, {
+    TransformOptions? transform,
+    ProgressCallback? onReceiveProgress,
+  }) async {
     final wantsTransformations = transform != null;
     final finalPath = _getFinalPath(path);
     final renderPath =
         wantsTransformations ? 'render/image/authenticated' : 'object';
     final queryParams = transform?.toQueryParams;
-    final options = FetchOptions(headers: headers, noResolveJson: true);
+    final options = FetchOptions(
+      headers: headers,
+      noResolveJson: true,
+      onResponseProgress: onReceiveProgress,
+    );
 
     var fetchUrl = Uri.parse('$url/$renderPath/$finalPath');
     fetchUrl = fetchUrl.replace(queryParameters: queryParams);

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,3 +1,6 @@
+// For tracking upload and dowmload progress. count and total are in bytes
+// (count is what is received so far, total is the total bytes expected, or -1
+// if contentLength of the response is null)
 typedef ProgressCallback = void Function(int count, int total);
 
 class FetchOptions {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -1,8 +1,17 @@
+typedef ProgressCallback = void Function(int count, int total);
+
 class FetchOptions {
   final Map<String, String>? headers;
   final bool? noResolveJson;
+  final ProgressCallback? onRequestProgress;
+  final ProgressCallback? onResponseProgress;
 
-  const FetchOptions({this.headers, this.noResolveJson});
+  const FetchOptions({
+    this.headers,
+    this.noResolveJson,
+    this.onRequestProgress,
+    this.onResponseProgress,
+  });
 }
 
 class Bucket {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds support for upload and download callbacks for file transfer operations. Fixes https://github.com/supabase/supabase-flutter/issues/308

## What is the current behavior?

At present there is no support for download/upload callbacks. This is an oft requested feature for the storage API, and one that is needed for various production uses of the Dart Supabase packages.

## What is the new behavior?

Now, the four upload operations in the `StorageFileApi` (`upload`, `uploadBinary`, `update`, and `updateBinary`) include the optional `onSendProgress` parameter, which is called for regular byte chunks that are transmitted. Likewise, the `download` function includes an optional `onReceiveProgress` callback, which functions in the same way.

These callbacks have the signature `void Function(int count, int total)`, where `count` is the number of bytes transferred up to that moment, and `total` is the total expected number of bytes for the whole transfer operation (or -1 if unknown). The total bytes includes not only the file size, but also the request/response envelope size. This signature is used as it is allows precise tracking of not only the relative progress (`count.toDouble() / total`), but also the actual bytes in question, which can be useful in reporting and logging transferred data.

## Additional context

For reference, some of the related discussions on this topics include:
- https://github.com/supabase/supabase-flutter/issues/76
- https://github.com/supabase/supabase-flutter/issues/308
- https://github.com/supabase/storage-api/issues/23
- https://github.com/supabase/storage-dart/pull/47
- https://github.com/supabase/supabase-flutter/issues/443

Integration of the TUS protocol (see https://github.com/supabase/supabase-flutter/issues/438) will likely affect the upload progress implementation here. In that case, this PR could serve as a temporary stopgap until TUS support is added, and also it could serve as an opportunity to establish the desired API interface (parameter names, etc.) for progress callbacks.
